### PR TITLE
IDE fix to stop annoying 'Declare 'jQuery' as instance variable?' alert.

### DIFF
--- a/st/IDE.st
+++ b/st/IDE.st
@@ -1,4 +1,3 @@
-Smalltalk current createPackage: 'IDE'!
 Widget subclass: #TabManager
 	instanceVariableNames: 'selectedTab tabs opened ul input'
 	category: 'IDE'!
@@ -600,9 +599,11 @@ compileMethodDefinitionFor: aClass
     method := compiler eval: (compiler compileNode: node).
     method category: selectedProtocol.
     compiler unknownVariables do: [:each |
-	(self confirm: 'Declare ''', each, ''' as instance variable?') ifTrue: [
-		self addInstanceVariableNamed: each toClass: aClass.
-		^self compileMethodDefinitionFor: aClass]].
+        "Do not try to redeclare javascript's objects"
+        (window at: each) ifNil: [
+		(self confirm: 'Declare ''', each, ''' as instance variable?') ifTrue: [
+			self addInstanceVariableNamed: each toClass: aClass.
+			^self compileMethodDefinitionFor: aClass]]].
     aClass addCompiledMethod: method.
     compiler setupClass: aClass.
     self updateMethodsList.
@@ -788,10 +789,9 @@ renamePackage
 
   | newName |
   newName := self prompt: 'Rename package ', selectedPackage.
-  newName ifNotNil: [
-    newName notEmpty ifTrue: [
+  newName notEmpty ifTrue: [
 	Smalltalk current renamePackage: selectedPackage to: newName.
-	self updateCategoriesList]]
+	self updateCategoriesList]
 !
 
 removePackage


### PR DESCRIPTION
Check if "window" object contains "unknown" variable before prompting alert.
