### PR TITLE
Fixes for the IDE

### DIFF
--- a/js/IDE.deploy.js
+++ b/js/IDE.deploy.js
@@ -1199,10 +1199,13 @@ smalltalk.addMethod(
 "_compile",
 smalltalk.method({
 selector: "compile",
-fn: function () {
+fn: function (){
 var self=this;
+var currentEditLine=nil;
 smalltalk.send(self, "_disableSaveButton", []);
+(currentEditLine=smalltalk.send(smalltalk.send(self['@sourceArea'], "_editor", []), "_getCursor", []));
 ((($receiver = smalltalk.send(self['@selectedTab'], "__eq", [smalltalk.symbolFor("comment")])).klass === smalltalk.Boolean) ? ($receiver ? (function(){return (($receiver = self['@selectedClass']) != nil && $receiver != undefined) ? (function(){return smalltalk.send(self, "_compileClassComment", []);})() : nil;})() : (function(){return ((($receiver = smalltalk.send(smalltalk.send(self['@selectedProtocol'], "_notNil", []), "_or_", [(function(){return smalltalk.send(self['@selectedMethod'], "_notNil", []);})])).klass === smalltalk.Boolean) ? (! $receiver ? (function(){return smalltalk.send(self, "_compileDefinition", []);})() : (function(){return smalltalk.send(self, "_compileMethodDefinition", []);})()) : smalltalk.send($receiver, "_ifFalse_ifTrue_", [(function(){return smalltalk.send(self, "_compileDefinition", []);}), (function(){return smalltalk.send(self, "_compileMethodDefinition", []);})]));})()) : smalltalk.send($receiver, "_ifTrue_ifFalse_", [(function(){return (($receiver = self['@selectedClass']) != nil && $receiver != undefined) ? (function(){return smalltalk.send(self, "_compileClassComment", []);})() : nil;}), (function(){return ((($receiver = smalltalk.send(smalltalk.send(self['@selectedProtocol'], "_notNil", []), "_or_", [(function(){return smalltalk.send(self['@selectedMethod'], "_notNil", []);})])).klass === smalltalk.Boolean) ? (! $receiver ? (function(){return smalltalk.send(self, "_compileDefinition", []);})() : (function(){return smalltalk.send(self, "_compileMethodDefinition", []);})()) : smalltalk.send($receiver, "_ifFalse_ifTrue_", [(function(){return smalltalk.send(self, "_compileDefinition", []);}), (function(){return smalltalk.send(self, "_compileMethodDefinition", []);})]));})]));
+smalltalk.send(smalltalk.send(self['@sourceArea'], "_editor", []), "_setCursor_", [currentEditLine]);
 return self;}
 }),
 smalltalk.Browser);

--- a/js/IDE.js
+++ b/js/IDE.js
@@ -1680,14 +1680,17 @@ smalltalk.addMethod(
 smalltalk.method({
 selector: "compile",
 category: 'actions',
-fn: function () {
+fn: function (){
 var self=this;
+var currentEditLine=nil;
 smalltalk.send(self, "_disableSaveButton", []);
+(currentEditLine=smalltalk.send(smalltalk.send(self['@sourceArea'], "_editor", []), "_getCursor", []));
 ((($receiver = smalltalk.send(self['@selectedTab'], "__eq", [smalltalk.symbolFor("comment")])).klass === smalltalk.Boolean) ? ($receiver ? (function(){return (($receiver = self['@selectedClass']) != nil && $receiver != undefined) ? (function(){return smalltalk.send(self, "_compileClassComment", []);})() : nil;})() : (function(){return ((($receiver = smalltalk.send(smalltalk.send(self['@selectedProtocol'], "_notNil", []), "_or_", [(function(){return smalltalk.send(self['@selectedMethod'], "_notNil", []);})])).klass === smalltalk.Boolean) ? (! $receiver ? (function(){return smalltalk.send(self, "_compileDefinition", []);})() : (function(){return smalltalk.send(self, "_compileMethodDefinition", []);})()) : smalltalk.send($receiver, "_ifFalse_ifTrue_", [(function(){return smalltalk.send(self, "_compileDefinition", []);}), (function(){return smalltalk.send(self, "_compileMethodDefinition", []);})]));})()) : smalltalk.send($receiver, "_ifTrue_ifFalse_", [(function(){return (($receiver = self['@selectedClass']) != nil && $receiver != undefined) ? (function(){return smalltalk.send(self, "_compileClassComment", []);})() : nil;}), (function(){return ((($receiver = smalltalk.send(smalltalk.send(self['@selectedProtocol'], "_notNil", []), "_or_", [(function(){return smalltalk.send(self['@selectedMethod'], "_notNil", []);})])).klass === smalltalk.Boolean) ? (! $receiver ? (function(){return smalltalk.send(self, "_compileDefinition", []);})() : (function(){return smalltalk.send(self, "_compileMethodDefinition", []);})()) : smalltalk.send($receiver, "_ifFalse_ifTrue_", [(function(){return smalltalk.send(self, "_compileDefinition", []);}), (function(){return smalltalk.send(self, "_compileMethodDefinition", []);})]));})]));
+smalltalk.send(smalltalk.send(self['@sourceArea'], "_editor", []), "_setCursor_", [currentEditLine]);
 return self;},
 args: [],
-source: "compile\x0a    self disableSaveButton.\x0a    selectedTab = #comment \x0a\x09ifTrue: [\x0a\x09\x09\x09selectedClass ifNotNil: [\x0a\x09\x09\x09\x09self compileClassComment]]\x0a\x09ifFalse: [\x0a\x09\x09\x09(selectedProtocol notNil or: [selectedMethod notNil])\x0a\x09\x09\x09\x09ifFalse: [self compileDefinition]\x0a\x09\x09\x09\x09ifTrue: [self compileMethodDefinition]]",
-messageSends: ["disableSaveButton", "ifTrue:ifFalse:", "=", "ifNotNil:", "compileClassComment", "ifFalse:ifTrue:", "or:", "notNil", "compileDefinition", "compileMethodDefinition"],
+source: "compile\x0a    | currentEditLine |\x0a    self disableSaveButton.\x0a    currentEditLine := sourceArea editor getCursor.\x0a    selectedTab = #comment \x0a\x09ifTrue: [\x0a\x09\x09\x09selectedClass ifNotNil: [\x0a\x09\x09\x09\x09self compileClassComment]]\x0a\x09ifFalse: [\x0a\x09\x09\x09(selectedProtocol notNil or: [selectedMethod notNil])\x0a\x09\x09\x09\x09ifFalse: [self compileDefinition]\x0a\x09\x09\x09\x09ifTrue: [self compileMethodDefinition]].\x0a    sourceArea editor setCursor: currentEditLine.",
+messageSends: ["disableSaveButton", "getCursor", "editor", "ifTrue:ifFalse:", "=", "ifNotNil:", "compileClassComment", "ifFalse:ifTrue:", "or:", "notNil", "compileDefinition", "compileMethodDefinition", "setCursor:"],
 referencedClasses: []
 }),
 smalltalk.Browser);

--- a/st/IDE.st
+++ b/st/IDE.st
@@ -797,7 +797,9 @@ commitPackage
 !
 
 compile
+    | currentEditLine |
     self disableSaveButton.
+    currentEditLine := sourceArea editor getCursor.
     selectedTab = #comment 
 	ifTrue: [
 			selectedClass ifNotNil: [
@@ -805,7 +807,8 @@ compile
 	ifFalse: [
 			(selectedProtocol notNil or: [selectedMethod notNil])
 				ifFalse: [self compileDefinition]
-				ifTrue: [self compileMethodDefinition]]
+				ifTrue: [self compileMethodDefinition]].
+    sourceArea editor setCursor: currentEditLine.
 !
 
 compileClassComment


### PR DESCRIPTION
The first fix is that the cursor stays at the current edit location if you press `save` and the code gets compiled.

Comments are welcome and some more fixes will be added to this pull request as time permits.
