### PR TITLE
IDE/SourceArea: focus editor after >>printIt (fixes #89)

### DIFF
--- a/js/IDE.deploy.js
+++ b/js/IDE.deploy.js
@@ -435,6 +435,17 @@ fn: function () {
 smalltalk.SourceArea);
 
 smalltalk.addMethod(
+"_focus",
+smalltalk.method({
+selector: "focus",
+fn: function (){
+var self=this;
+smalltalk.send(smalltalk.send(self,"_editor",[]),"_focus",[]);
+return self}
+}),
+smalltalk.SourceArea);
+
+smalltalk.addMethod(
 "_handleKeyDown_",
 smalltalk.method({
 selector: "handleKeyDown:",
@@ -550,7 +561,7 @@ selector: "printIt",
 fn: function (){
 var self=this;
 smalltalk.send(self,"_print_",[smalltalk.send(smalltalk.send(self,"_doIt",[]),"_printString",[])]);
-smalltalk.send(smalltalk.send(self,"_editor",[]),"_focus",[]);
+smalltalk.send(self,"_focus",[]);
 return self}
 }),
 smalltalk.SourceArea);
@@ -4405,6 +4416,18 @@ fn: function (html) {
     $10 = smalltalk.send($9, "_onClick_", [function () {return smalltalk.send(self, "_clearWorkspace", []);}]);
     return self;
 }
+}),
+smalltalk.Workspace);
+
+smalltalk.addMethod(
+"_show",
+smalltalk.method({
+selector: "show",
+fn: function (){
+var self=this;
+smalltalk.send(self,"_show",[],smalltalk.TabWidget);
+smalltalk.send(self["@sourceArea"],"_focus",[]);
+return self}
 }),
 smalltalk.Workspace);
 

--- a/js/IDE.js
+++ b/js/IDE.js
@@ -580,6 +580,22 @@ referencedClasses: ["Importer"]
 smalltalk.SourceArea);
 
 smalltalk.addMethod(
+"_focus",
+smalltalk.method({
+selector: "focus",
+category: 'actions',
+fn: function (){
+var self=this;
+smalltalk.send(smalltalk.send(self,"_editor",[]),"_focus",[]);
+return self},
+args: [],
+source: "focus\x0a      self editor focus.",
+messageSends: ["focus", "editor"],
+referencedClasses: []
+}),
+smalltalk.SourceArea);
+
+smalltalk.addMethod(
 "_handleKeyDown_",
 smalltalk.method({
 selector: "handleKeyDown:",
@@ -731,11 +747,11 @@ category: 'actions',
 fn: function (){
 var self=this;
 smalltalk.send(self,"_print_",[smalltalk.send(smalltalk.send(self,"_doIt",[]),"_printString",[])]);
-smalltalk.send(smalltalk.send(self,"_editor",[]),"_focus",[]);
+smalltalk.send(self,"_focus",[]);
 return self},
 args: [],
-source: "printIt\x0a    self print: self doIt printString.\x0a    self editor focus.",
-messageSends: ["print:", "printString", "doIt", "focus", "editor"],
+source: "printIt\x0a    self print: self doIt printString.\x0a\x09self focus.",
+messageSends: ["print:", "printString", "doIt", "focus"],
 referencedClasses: []
 }),
 smalltalk.SourceArea);
@@ -5804,6 +5820,23 @@ fn: function (html) {
 args: ["html"],
 source: "renderButtonsOn: html\x0a    html button\x0a\x09with: 'DoIt';\x0a\x09title: 'ctrl+d';\x0a\x09onClick: [self doIt].\x0a    html button\x0a\x09with: 'PrintIt';\x0a\x09title: 'ctrl+p';\x0a\x09onClick: [self printIt].\x0a    html button\x0a\x09with: 'InspectIt';\x0a\x09title: 'ctrl+i';\x0a\x09onClick: [self inspectIt].\x0a    html button\x0a\x09with: 'FileIn';\x0a\x09title: 'ctrl+f';\x0a\x09onClick: [self fileIn].\x0a    html button\x0a\x09with: 'Clear workspace';\x0a\x09onClick: [self clearWorkspace]",
 messageSends: ["with:", "button", "title:", "onClick:", "doIt", "printIt", "inspectIt", "fileIn", "clearWorkspace"],
+referencedClasses: []
+}),
+smalltalk.Workspace);
+
+smalltalk.addMethod(
+"_show",
+smalltalk.method({
+selector: "show",
+category: 'actions',
+fn: function (){
+var self=this;
+smalltalk.send(self,"_show",[],smalltalk.TabWidget);
+smalltalk.send(self["@sourceArea"],"_focus",[]);
+return self},
+args: [],
+source: "show\x0a\x09super show.\x0a\x09sourceArea focus.",
+messageSends: ["show", "focus"],
 referencedClasses: []
 }),
 smalltalk.Workspace);

--- a/st/IDE.st
+++ b/st/IDE.st
@@ -267,6 +267,10 @@ fileIn
     Importer new import: self currentLineOrSelection readStream
 !
 
+focus
+      self editor focus.
+!
+
 handleKeyDown: anEvent
     <if(anEvent.ctrlKey) {
 		if(anEvent.keyCode === 80) { //ctrl+p
@@ -306,7 +310,7 @@ print: aString
 
 printIt
     self print: self doIt printString.
-    self editor focus.
+	self focus.
 ! !
 
 !SourceArea methodsFor: 'events'!
@@ -2261,6 +2265,11 @@ inspectIt
 
 printIt
 	sourceArea printIt
+!
+
+show
+	super show.
+	sourceArea focus.
 ! !
 
 !Workspace methodsFor: 'rendering'!


### PR DESCRIPTION
After pressing the `printIt` button the editor of `SourceArea` looses focus so the added text can not be deleted immediately.
This patch calls `editor focus` afterwards to fix this problem.
