### PR TITLE
JSObjectProxy>>#doesNotUnderstand: treats undefined values as missing selector

### DIFF
--- a/js/Kernel-Objects.deploy.js
+++ b/js/Kernel-Objects.deploy.js
@@ -1470,22 +1470,20 @@ smalltalk.addMethod(
 "_doesNotUnderstand_",
 smalltalk.method({
 selector: "doesNotUnderstand:",
-fn: function (aMessage) {
-    var self = this;
-    var obj;
-    var selector;
-    var jsSelector;
-    var arguments;
-    obj = smalltalk.send(self, "_jsObject", []);
-    selector = smalltalk.send(aMessage, "_selector", []);
-    jsSelector = smalltalk.send(selector, "_asJavaScriptSelector", []);
-    arguments = smalltalk.send(aMessage, "_arguments", []);
-    if (obj[jsSelector] != undefined) {
-        return smalltalk.send(obj, jsSelector, arguments);
-    }
-    smalltalk.send(self, "_doesNotUnderstand_", [aMessage], smalltalk.Object);
-    return self;
-}
+fn: function (aMessage){
+var self=this;
+var obj;
+var selector;
+var jsSelector;
+var arguments;
+obj=smalltalk.send(self,"_jsObject",[]);
+selector=smalltalk.send(aMessage,"_selector",[]);
+jsSelector=smalltalk.send(selector,"_asJavaScriptSelector",[]);
+arguments=smalltalk.send(aMessage,"_arguments",[]);
+if(jsSelector in obj) {return smalltalk.send(obj, jsSelector, arguments)};
+;
+smalltalk.send(self,"_doesNotUnderstand_",[aMessage],smalltalk.Object);
+return self}
 }),
 smalltalk.JSObjectProxy);
 

--- a/js/Kernel-Objects.js
+++ b/js/Kernel-Objects.js
@@ -2045,24 +2045,22 @@ smalltalk.addMethod(
 smalltalk.method({
 selector: "doesNotUnderstand:",
 category: 'proxy',
-fn: function (aMessage) {
-    var self = this;
-    var obj;
-    var selector;
-    var jsSelector;
-    var arguments;
-    obj = smalltalk.send(self, "_jsObject", []);
-    selector = smalltalk.send(aMessage, "_selector", []);
-    jsSelector = smalltalk.send(selector, "_asJavaScriptSelector", []);
-    arguments = smalltalk.send(aMessage, "_arguments", []);
-    if (obj[jsSelector] != undefined) {
-        return smalltalk.send(obj, jsSelector, arguments);
-    }
-    smalltalk.send(self, "_doesNotUnderstand_", [aMessage], smalltalk.Object);
-    return self;
-},
+fn: function (aMessage){
+var self=this;
+var obj;
+var selector;
+var jsSelector;
+var arguments;
+obj=smalltalk.send(self,"_jsObject",[]);
+selector=smalltalk.send(aMessage,"_selector",[]);
+jsSelector=smalltalk.send(selector,"_asJavaScriptSelector",[]);
+arguments=smalltalk.send(aMessage,"_arguments",[]);
+if(jsSelector in obj) {return smalltalk.send(obj, jsSelector, arguments)};
+;
+smalltalk.send(self,"_doesNotUnderstand_",[aMessage],smalltalk.Object);
+return self},
 args: ["aMessage"],
-source: "doesNotUnderstand: aMessage\x0a\x09| obj selector jsSelector arguments |\x0a\x09obj := self jsObject.\x0a\x09selector := aMessage selector.\x0a\x09jsSelector := selector asJavaScriptSelector.\x0a\x09arguments := aMessage arguments.\x0a\x09<if(obj[jsSelector] != undefined) {return smalltalk.send(obj, jsSelector, arguments)}>.\x0a\x09super doesNotUnderstand: aMessage",
+source: "doesNotUnderstand: aMessage\x0a\x09| obj selector jsSelector arguments |\x0a\x09obj := self jsObject.\x0a\x09selector := aMessage selector.\x0a\x09jsSelector := selector asJavaScriptSelector.\x0a\x09arguments := aMessage arguments.\x0a\x09<if(jsSelector in obj) {return smalltalk.send(obj, jsSelector, arguments)}>.\x0a\x09super doesNotUnderstand: aMessage",
 messageSends: ["jsObject", "selector", "asJavaScriptSelector", "arguments", "doesNotUnderstand:"],
 referencedClasses: []
 }),

--- a/js/Kernel-Tests.deploy.js
+++ b/js/Kernel-Tests.deploy.js
@@ -1596,7 +1596,7 @@ smalltalk.method({
 selector: "jsObject",
 fn: function (){
 var self=this;
-return jsObject = {a: 1, b: function() {return 2;}, c: function(object) {return object;}, d: ''};
+return jsObject = {a: 1, b: function() {return 2;}, c: function(object) {return object;}, d: '', 'e': null};
 ;
 return self}
 }),
@@ -1661,6 +1661,22 @@ object=smalltalk.send(self,"_jsObject",[]);
 smalltalk.send(self,"_assert_equals_",["",smalltalk.send(object,"_d",[])]);
 smalltalk.send(object,"_d_",["hello"]);
 smalltalk.send(self,"_assert_equals_",["hello",smalltalk.send(object,"_d",[])]);
+return self}
+}),
+smalltalk.JSObjectProxyTest);
+
+smalltalk.addMethod(
+"_testPropertyThatReturnsUndefined",
+smalltalk.method({
+selector: "testPropertyThatReturnsUndefined",
+fn: function (){
+var self=this;
+var object;
+object=smalltalk.send(self,"_jsObject",[]);
+smalltalk.send(self,"_shouldnt_raise_",[(function(){
+return smalltalk.send(object,"_e",[]);
+}),(smalltalk.MessageNotUnderstood || MessageNotUnderstood)]);
+smalltalk.send(self,"_assert_",[smalltalk.send(smalltalk.send(object,"_e",[]),"_isNil",[])]);
 return self}
 }),
 smalltalk.JSObjectProxyTest);

--- a/js/Kernel-Tests.js
+++ b/js/Kernel-Tests.js
@@ -2072,11 +2072,11 @@ selector: "jsObject",
 category: 'accessing',
 fn: function (){
 var self=this;
-return jsObject = {a: 1, b: function() {return 2;}, c: function(object) {return object;}, d: ''};
+return jsObject = {a: 1, b: function() {return 2;}, c: function(object) {return object;}, d: '', 'e': null};
 ;
 return self},
 args: [],
-source: "jsObject\x0a\x09<return jsObject = {a: 1, b: function() {return 2;}, c: function(object) {return object;}, d: ''}>",
+source: "jsObject\x0a\x09<return jsObject = {a: 1, b: function() {return 2;}, c: function(object) {return object;}, d: '', 'e': null}>",
 messageSends: [],
 referencedClasses: []
 }),
@@ -2167,6 +2167,27 @@ args: [],
 source: "testPropertyThatReturnsEmptyString\x0a\x09| object |\x0a\x0a\x09object := self jsObject.\x0a\x09self assert: '' equals: object d.\x0a\x0a\x09object d: 'hello'.\x0a\x09self assert: 'hello' equals: object d",
 messageSends: ["jsObject", "assert:equals:", "d", "d:"],
 referencedClasses: []
+}),
+smalltalk.JSObjectProxyTest);
+
+smalltalk.addMethod(
+"_testPropertyThatReturnsUndefined",
+smalltalk.method({
+selector: "testPropertyThatReturnsUndefined",
+category: 'tests',
+fn: function (){
+var self=this;
+var object;
+object=smalltalk.send(self,"_jsObject",[]);
+smalltalk.send(self,"_shouldnt_raise_",[(function(){
+return smalltalk.send(object,"_e",[]);
+}),(smalltalk.MessageNotUnderstood || MessageNotUnderstood)]);
+smalltalk.send(self,"_assert_",[smalltalk.send(smalltalk.send(object,"_e",[]),"_isNil",[])]);
+return self},
+args: [],
+source: "testPropertyThatReturnsUndefined\x0a\x09| object |\x0a\x0a\x09object := self jsObject.\x0a\x09self shouldnt: [ object e ]  raise: MessageNotUnderstood.\x0a    self assert: object e isNil\x0a",
+messageSends: ["jsObject", "shouldnt:raise:", "e", "assert:", "isNil"],
+referencedClasses: ["MessageNotUnderstood"]
 }),
 smalltalk.JSObjectProxyTest);
 

--- a/st/Kernel-Objects.st
+++ b/st/Kernel-Objects.st
@@ -683,7 +683,7 @@ doesNotUnderstand: aMessage
 	selector := aMessage selector.
 	jsSelector := selector asJavaScriptSelector.
 	arguments := aMessage arguments.
-	<if(obj[jsSelector] !!= undefined) {return smalltalk.send(obj, jsSelector, arguments)}>.
+	<if(jsSelector in obj) {return smalltalk.send(obj, jsSelector, arguments)}>.
 	super doesNotUnderstand: aMessage
 !
 

--- a/st/Kernel-Tests.st
+++ b/st/Kernel-Tests.st
@@ -826,7 +826,7 @@ TestCase subclass: #JSObjectProxyTest
 !JSObjectProxyTest methodsFor: 'accessing'!
 
 jsObject
-	<return jsObject = {a: 1, b: function() {return 2;}, c: function(object) {return object;}, d: ''}>
+	<return jsObject = {a: 1, b: function() {return 2;}, c: function(object) {return object;}, d: '', 'e': null}>
 ! !
 
 !JSObjectProxyTest methodsFor: 'tests'!
@@ -858,6 +858,14 @@ testPropertyThatReturnsEmptyString
 
 	object d: 'hello'.
 	self assert: 'hello' equals: object d
+!
+
+testPropertyThatReturnsUndefined
+	| object |
+
+	object := self jsObject.
+	self shouldnt: [ object e ]  raise: MessageNotUnderstood.
+    self assert: object e isNil
 !
 
 testYourself


### PR DESCRIPTION
Fixed a bug in JSObjectProxy>>#doesNotUnderstand: The check for
an existing property was evaluating the property content. So
a missing property and an existing property with undefined value
both triggered MessageNotUnderstood.
Fix and tests are included
