### PR TITLE
amberc for -?.--help -H call print_usage without this.

### DIFF
--- a/bin/amberc
+++ b/bin/amberc
@@ -77,7 +77,7 @@ function handle_options(optionsArray, amber_dir) {
 			case '-h':
 			case '--help':
 			case '?':
-				this.usage();
+				print_usage();
 				break;
 			default:
 				var fileSuffix = path.extname(currentItem);


### PR DESCRIPTION
Fix an command line option bug for --Help on bin/amberc.

Bug is

bin/amberc --help 

reports and error no method 'usage'
