### PR TITLE
class Counterzzz renamed to Counter

### DIFF
--- a/js/Examples.deploy.js
+++ b/js/Examples.deploy.js
@@ -1,5 +1,5 @@
 smalltalk.addPackage('Examples');
-smalltalk.addClass('Counterzzz', smalltalk.Widget, ['count', 'header'], 'Examples');
+smalltalk.addClass('Counter', smalltalk.Widget, ['count', 'header'], 'Examples');
 smalltalk.addMethod(
 smalltalk.method({
 selector: "decrease",
@@ -11,9 +11,9 @@ _st(self["@header"])._contents_((function(html){
 return smalltalk.withContext(function($ctx2) {
 return _st(html)._with_(_st(self["@count"])._asString());
 }, function($ctx2) {$ctx2.fillBlock({html:html},$ctx1)})}));
-return self}, function($ctx1) {$ctx1.fill(self,"decrease",{},smalltalk.Counterzzz)})},
+return self}, function($ctx1) {$ctx1.fill(self,"decrease",{},smalltalk.Counter)})},
 messageSends: ["-", "contents:", "with:", "asString"]}),
-smalltalk.Counterzzz);
+smalltalk.Counter);
 
 smalltalk.addMethod(
 smalltalk.method({
@@ -26,9 +26,9 @@ _st(self["@header"])._contents_((function(html){
 return smalltalk.withContext(function($ctx2) {
 return _st(html)._with_(_st(self["@count"])._asString());
 }, function($ctx2) {$ctx2.fillBlock({html:html},$ctx1)})}));
-return self}, function($ctx1) {$ctx1.fill(self,"increase",{},smalltalk.Counterzzz)})},
+return self}, function($ctx1) {$ctx1.fill(self,"increase",{},smalltalk.Counter)})},
 messageSends: ["+", "contents:", "with:", "asString"]}),
-smalltalk.Counterzzz);
+smalltalk.Counter);
 
 smalltalk.addMethod(
 smalltalk.method({
@@ -36,11 +36,11 @@ selector: "initialize",
 fn: function (){
 var self=this;
 return smalltalk.withContext(function($ctx1) { 
-smalltalk.Counterzzz.superclass.fn.prototype._initialize.apply(_st(self), []);
+smalltalk.Counter.superclass.fn.prototype._initialize.apply(_st(self), []);
 self["@count"]=(0);
-return self}, function($ctx1) {$ctx1.fill(self,"initialize",{},smalltalk.Counterzzz)})},
+return self}, function($ctx1) {$ctx1.fill(self,"initialize",{},smalltalk.Counter)})},
 messageSends: ["initialize"]}),
-smalltalk.Counterzzz);
+smalltalk.Counter);
 
 smalltalk.addMethod(
 smalltalk.method({
@@ -65,9 +65,9 @@ $6=_st($5)._onClick_((function(){
 return smalltalk.withContext(function($ctx2) {
 return self._decrease();
 }, function($ctx2) {$ctx2.fillBlock({},$ctx1)})}));
-return self}, function($ctx1) {$ctx1.fill(self,"renderOn:",{html:html},smalltalk.Counterzzz)})},
+return self}, function($ctx1) {$ctx1.fill(self,"renderOn:",{html:html},smalltalk.Counter)})},
 messageSends: ["with:", "asString", "h1", "yourself", "button", "onClick:", "increase", "decrease"]}),
-smalltalk.Counterzzz);
+smalltalk.Counter);
 
 
 smalltalk.addMethod(
@@ -77,8 +77,8 @@ fn: function (){
 var self=this;
 return smalltalk.withContext(function($ctx1) { 
 _st(self._new())._appendToJQuery_("body"._asJQuery());
-return self}, function($ctx1) {$ctx1.fill(self,"tryExample",{},smalltalk.Counterzzz.klass)})},
+return self}, function($ctx1) {$ctx1.fill(self,"tryExample",{},smalltalk.Counter.klass)})},
 messageSends: ["appendToJQuery:", "asJQuery", "new"]}),
-smalltalk.Counterzzz.klass);
+smalltalk.Counter.klass);
 
 

--- a/js/Examples.js
+++ b/js/Examples.js
@@ -1,6 +1,6 @@
 smalltalk.addPackage('Examples');
-smalltalk.addClass('Counterzzz', smalltalk.Widget, ['count', 'header'], 'Examples');
-smalltalk.Counterzzz.comment="This is a trivial Widget example mimicking the classic Counter example in Seaside.\x0aIn order to play with it, just evaluate the doit below in a workspace.\x0aThen take a look in the HTML document above the IDE.\x0a\x0a\x09\x09Counter new appendToJQuery: 'body' asJQuery";
+smalltalk.addClass('Counter', smalltalk.Widget, ['count', 'header'], 'Examples');
+smalltalk.Counter.comment="This is a trivial Widget example mimicking the classic Counter example in Seaside.\x0aIn order to play with it, just evaluate the doit below in a workspace.\x0aThen take a look in the HTML document above the IDE.\x0a\x0a\x09\x09Counter new appendToJQuery: 'body' asJQuery";
 smalltalk.addMethod(
 smalltalk.method({
 selector: "decrease",
@@ -13,13 +13,13 @@ _st(self["@header"])._contents_((function(html){
 return smalltalk.withContext(function($ctx2) {
 return _st(html)._with_(_st(self["@count"])._asString());
 }, function($ctx2) {$ctx2.fillBlock({html:html},$ctx1)})}));
-return self}, function($ctx1) {$ctx1.fill(self,"decrease",{},smalltalk.Counterzzz)})},
+return self}, function($ctx1) {$ctx1.fill(self,"decrease",{},smalltalk.Counter)})},
 args: [],
 source: "decrease\x0a\x09count := count - 1.\x0a\x09header contents: [:html | html with: count asString]",
 messageSends: ["-", "contents:", "with:", "asString"],
 referencedClasses: []
 }),
-smalltalk.Counterzzz);
+smalltalk.Counter);
 
 smalltalk.addMethod(
 smalltalk.method({
@@ -33,13 +33,13 @@ _st(self["@header"])._contents_((function(html){
 return smalltalk.withContext(function($ctx2) {
 return _st(html)._with_(_st(self["@count"])._asString());
 }, function($ctx2) {$ctx2.fillBlock({html:html},$ctx1)})}));
-return self}, function($ctx1) {$ctx1.fill(self,"increase",{},smalltalk.Counterzzz)})},
+return self}, function($ctx1) {$ctx1.fill(self,"increase",{},smalltalk.Counter)})},
 args: [],
 source: "increase\x0a\x09count := count + 1.\x0a\x09header contents: [:html | html with: count asString]",
 messageSends: ["+", "contents:", "with:", "asString"],
 referencedClasses: []
 }),
-smalltalk.Counterzzz);
+smalltalk.Counter);
 
 smalltalk.addMethod(
 smalltalk.method({
@@ -48,15 +48,15 @@ category: 'initialization',
 fn: function (){
 var self=this;
 return smalltalk.withContext(function($ctx1) { 
-smalltalk.Counterzzz.superclass.fn.prototype._initialize.apply(_st(self), []);
+smalltalk.Counter.superclass.fn.prototype._initialize.apply(_st(self), []);
 self["@count"]=(0);
-return self}, function($ctx1) {$ctx1.fill(self,"initialize",{},smalltalk.Counterzzz)})},
+return self}, function($ctx1) {$ctx1.fill(self,"initialize",{},smalltalk.Counter)})},
 args: [],
 source: "initialize\x0a\x09super initialize.\x0a\x09count := 0",
 messageSends: ["initialize"],
 referencedClasses: []
 }),
-smalltalk.Counterzzz);
+smalltalk.Counter);
 
 smalltalk.addMethod(
 smalltalk.method({
@@ -82,13 +82,13 @@ $6=_st($5)._onClick_((function(){
 return smalltalk.withContext(function($ctx2) {
 return self._decrease();
 }, function($ctx2) {$ctx2.fillBlock({},$ctx1)})}));
-return self}, function($ctx1) {$ctx1.fill(self,"renderOn:",{html:html},smalltalk.Counterzzz)})},
+return self}, function($ctx1) {$ctx1.fill(self,"renderOn:",{html:html},smalltalk.Counter)})},
 args: ["html"],
 source: "renderOn: html\x0a\x09header := html h1\x0a\x09with: count asString;\x0a\x09yourself.\x0a\x09html button\x0a\x09with: '++';\x0a\x09onClick: [self increase].\x0a\x09html button\x0a\x09with: '--';\x0a\x09onClick: [self decrease]",
 messageSends: ["with:", "asString", "h1", "yourself", "button", "onClick:", "increase", "decrease"],
 referencedClasses: []
 }),
-smalltalk.Counterzzz);
+smalltalk.Counter);
 
 
 smalltalk.addMethod(
@@ -99,12 +99,12 @@ fn: function (){
 var self=this;
 return smalltalk.withContext(function($ctx1) { 
 _st(self._new())._appendToJQuery_("body"._asJQuery());
-return self}, function($ctx1) {$ctx1.fill(self,"tryExample",{},smalltalk.Counterzzz.klass)})},
+return self}, function($ctx1) {$ctx1.fill(self,"tryExample",{},smalltalk.Counter.klass)})},
 args: [],
 source: "tryExample\x0a\x09\x22In order to play with the Counter, just select the\x0a\x09doit below and press the Do it button. Then take a\x0a\x09look in the HTML document above the IDE.\x22\x0a\x0a\x09\x22Counter tryExample\x22\x0a\x09\x09self new appendToJQuery: 'body' asJQuery",
 messageSends: ["appendToJQuery:", "asJQuery", "new"],
 referencedClasses: []
 }),
-smalltalk.Counterzzz.klass);
+smalltalk.Counter.klass);
 
 

--- a/st/Examples.st
+++ b/st/Examples.st
@@ -1,15 +1,15 @@
 Smalltalk current createPackage: 'Examples'!
-Widget subclass: #Counterzzz
+Widget subclass: #Counter
 	instanceVariableNames: 'count header'
 	package: 'Examples'!
-!Counterzzz commentStamp!
+!Counter commentStamp!
 This is a trivial Widget example mimicking the classic Counter example in Seaside.
 In order to play with it, just evaluate the doit below in a workspace.
 Then take a look in the HTML document above the IDE.
 
 		Counter new appendToJQuery: 'body' asJQuery!
 
-!Counterzzz methodsFor: 'actions'!
+!Counter methodsFor: 'actions'!
 
 decrease
 	count := count - 1.
@@ -21,14 +21,14 @@ increase
 	header contents: [:html | html with: count asString]
 ! !
 
-!Counterzzz methodsFor: 'initialization'!
+!Counter methodsFor: 'initialization'!
 
 initialize
 	super initialize.
 	count := 0
 ! !
 
-!Counterzzz methodsFor: 'rendering'!
+!Counter methodsFor: 'rendering'!
 
 renderOn: html
 	header := html h1
@@ -42,7 +42,7 @@ renderOn: html
 	onClick: [self decrease]
 ! !
 
-!Counterzzz class methodsFor: 'example'!
+!Counter class methodsFor: 'example'!
 
 tryExample
 	"In order to play with the Counter, just select the


### PR DESCRIPTION
This fixes the presentation example which uses Counter. I thought I opened an issues on this about an hour ago. Counter is a Seaside example and Counterzzz seems like an debugging name to me.
