### PR TITLE
ASTInterpreter variable nodes: check for JS globals

### DIFF
--- a/js/Compiler-Interpreter.js
+++ b/js/Compiler-Interpreter.js
@@ -1062,17 +1062,18 @@ selector: "interpretClassReferenceNode:continue:",
 category: 'interpreting',
 fn: function (aNode,aBlock){
 var self=this;
+function $PlatformInterface(){return smalltalk.PlatformInterface||(typeof PlatformInterface=="undefined"?nil:PlatformInterface)}
 function $Smalltalk(){return smalltalk.Smalltalk||(typeof Smalltalk=="undefined"?nil:Smalltalk)}
 return smalltalk.withContext(function($ctx1) { 
 self._continue_value_(aBlock,_st(_st($Smalltalk())._current())._at_ifAbsent_(_st(aNode)._value(),(function(){
 return smalltalk.withContext(function($ctx2) {
-return _st(window)._at_(_st(aNode)._value());
+return _st($PlatformInterface())._globalAt_(_st(aNode)._value());
 }, function($ctx2) {$ctx2.fillBlock({},$ctx1)})})));
 return self}, function($ctx1) {$ctx1.fill(self,"interpretClassReferenceNode:continue:",{aNode:aNode,aBlock:aBlock},smalltalk.ASTInterpreter)})},
 args: ["aNode", "aBlock"],
-source: "interpretClassReferenceNode: aNode continue: aBlock\x0a\x09self \x0a\x09\x09continue: aBlock \x0a\x09\x09value: (Smalltalk current \x0a\x09\x09\x09at: aNode value\x0a\x09\x09\x09ifAbsent: [ window at: aNode value ])",
-messageSends: ["continue:value:", "at:ifAbsent:", "value", "at:", "current"],
-referencedClasses: ["Smalltalk"]
+source: "interpretClassReferenceNode: aNode continue: aBlock\x0a\x09self \x0a\x09\x09continue: aBlock \x0a\x09\x09value: (Smalltalk current \x0a\x09\x09\x09at: aNode value\x0a\x09\x09\x09ifAbsent: [ PlatformInterface globalAt: aNode value ])",
+messageSends: ["continue:value:", "at:ifAbsent:", "value", "globalAt:", "current"],
+referencedClasses: ["PlatformInterface", "Smalltalk"]
 }),
 smalltalk.ASTInterpreter);
 
@@ -1262,6 +1263,7 @@ selector: "interpretVariableNode:continue:",
 category: 'interpreting',
 fn: function (aNode,aBlock){
 var self=this;
+function $PlatformInterface(){return smalltalk.PlatformInterface||(typeof PlatformInterface=="undefined"?nil:PlatformInterface)}
 return smalltalk.withContext(function($ctx1) { 
 var $1,$2,$4,$3;
 $1=self;
@@ -1272,15 +1274,15 @@ $3=_st(_st(self._context())._receiver())._instVarAt_(_st(aNode)._value());
 } else {
 $3=_st(self._context())._localAt_ifAbsent_(_st(aNode)._value(),(function(){
 return smalltalk.withContext(function($ctx2) {
-return _st(window)._at_(_st(aNode)._value());
+return _st($PlatformInterface())._globalAt_(_st(aNode)._value());
 }, function($ctx2) {$ctx2.fillBlock({},$ctx1)})}));
 };
 _st($1)._continue_value_($2,$3);
 return self}, function($ctx1) {$ctx1.fill(self,"interpretVariableNode:continue:",{aNode:aNode,aBlock:aBlock},smalltalk.ASTInterpreter)})},
 args: ["aNode", "aBlock"],
-source: "interpretVariableNode: aNode continue: aBlock\x0a\x09self\x0a\x09\x09continue: aBlock\x0a\x09\x09value: (aNode binding isInstanceVar\x0a\x09\x09\x09ifTrue: [ self context receiver instVarAt: aNode value ]\x0a\x09\x09\x09ifFalse: [ self context \x0a\x09\x09\x09\x09localAt: aNode value \x0a\x09\x09\x09\x09ifAbsent: [ window at: aNode value ]])",
-messageSends: ["continue:value:", "ifTrue:ifFalse:", "instVarAt:", "value", "receiver", "context", "localAt:ifAbsent:", "at:", "isInstanceVar", "binding"],
-referencedClasses: []
+source: "interpretVariableNode: aNode continue: aBlock\x0a\x09self\x0a\x09\x09continue: aBlock\x0a\x09\x09value: (aNode binding isInstanceVar\x0a\x09\x09\x09ifTrue: [ self context receiver instVarAt: aNode value ]\x0a\x09\x09\x09ifFalse: [ self context \x0a\x09\x09\x09\x09localAt: aNode value \x0a\x09\x09\x09\x09ifAbsent: [ PlatformInterface globalAt: aNode value ]])",
+messageSends: ["continue:value:", "ifTrue:ifFalse:", "instVarAt:", "value", "receiver", "context", "localAt:ifAbsent:", "globalAt:", "isInstanceVar", "binding"],
+referencedClasses: ["PlatformInterface"]
 }),
 smalltalk.ASTInterpreter);
 

--- a/js/Compiler-Tests.js
+++ b/js/Compiler-Tests.js
@@ -392,23 +392,6 @@ smalltalk.ASTInterpreterTest);
 
 smalltalk.addMethod(
 smalltalk.method({
-selector: "testClassRefVarAccess",
-category: 'tests',
-fn: function (){
-var self=this;
-function $Object(){return smalltalk.Object||(typeof Object=="undefined"?nil:Object)}
-return smalltalk.withContext(function($ctx1) { 
-self._assert_equals_(self._interpret_("foo ^ Object"),$Object());
-return self}, function($ctx1) {$ctx1.fill(self,"testClassRefVarAccess",{},smalltalk.ASTInterpreterTest)})},
-args: [],
-source: "testClassRefVarAccess\x0a\x09self assert: (self interpret: 'foo ^ Object') equals: Object.",
-messageSends: ["assert:equals:", "interpret:"],
-referencedClasses: ["Object"]
-}),
-smalltalk.ASTInterpreterTest);
-
-smalltalk.addMethod(
-smalltalk.method({
 selector: "testDynamicArray",
 category: 'tests',
 fn: function (){
@@ -486,23 +469,6 @@ args: [],
 source: "testInstVarAssignment\x0a\x09self\x0a\x09\x09assert: (self\x0a\x09\x09\x09interpret: 'foo: anInteger x := anInteger. ^ x'\x0a\x09\x09\x09receiver: Point new\x0a\x09\x09\x09withArguments: #{'anInteger' -> 2})\x0a\x09\x09equals: 2",
 messageSends: ["assert:equals:", "interpret:receiver:withArguments:", "new", "->"],
 referencedClasses: ["Point"]
-}),
-smalltalk.ASTInterpreterTest);
-
-smalltalk.addMethod(
-smalltalk.method({
-selector: "testJSGlobalVarAccess",
-category: 'tests',
-fn: function (){
-var self=this;
-return smalltalk.withContext(function($ctx1) { 
-self._assert_equals_(self._interpret_("foo ^ Math cos: 0"),(1));
-self._assert_equals_(self._interpret_("foo ^ document title isString"),true);
-return self}, function($ctx1) {$ctx1.fill(self,"testJSGlobalVarAccess",{},smalltalk.ASTInterpreterTest)})},
-args: [],
-source: "testJSGlobalVarAccess\x0a\x09\x22Capital letter variables are treated differently.\x22\x0a\x09\x0a\x09self assert: (self interpret: 'foo ^ Math cos: 0') equals: 1.\x0a\x09self assert: (self interpret: 'foo ^ document title isString') equals: true.",
-messageSends: ["assert:equals:", "interpret:"],
-referencedClasses: []
 }),
 smalltalk.ASTInterpreterTest);
 
@@ -586,6 +552,27 @@ args: [],
 source: "testThisContext\x0a\x09self assert: (self interpret: 'foo ^ thisContext') outerContext isNil.\x0a\x09self assert: (self interpret: 'foo ^ [ thisContext ] value') outerContext notNil.\x0a\x09self assert: (self interpret: 'foo ^ [ thisContext ] value outerContext == thisContext')",
 messageSends: ["assert:", "isNil", "outerContext", "interpret:", "notNil"],
 referencedClasses: []
+}),
+smalltalk.ASTInterpreterTest);
+
+smalltalk.addMethod(
+smalltalk.method({
+selector: "testVariableAccess",
+category: 'tests',
+fn: function (){
+var self=this;
+function $Object(){return smalltalk.Object||(typeof Object=="undefined"?nil:Object)}
+function $BlockClosure(){return smalltalk.BlockClosure||(typeof BlockClosure=="undefined"?nil:BlockClosure)}
+return smalltalk.withContext(function($ctx1) { 
+self._assert_equals_(self._interpret_("foo ^ Object"),$Object());
+self._assert_equals_(self._interpret_("foo ^ Math cos: 0"),(1));
+self._assert_equals_(self._interpret_("foo ^ eval class"),$BlockClosure());
+self._assert_equals_(self._interpret_("foo ^ NonExistingVar"),nil);
+return self}, function($ctx1) {$ctx1.fill(self,"testVariableAccess",{},smalltalk.ASTInterpreterTest)})},
+args: [],
+source: "testVariableAccess\x0a\x09self assert: (self interpret: 'foo ^ Object') equals: Object.\x0a\x09self assert: (self interpret: 'foo ^ Math cos: 0') equals: 1.\x0a\x09self assert: (self interpret: 'foo ^ eval class') equals: BlockClosure.\x0a\x09self assert: (self interpret: 'foo ^ NonExistingVar') equals: nil.",
+messageSends: ["assert:equals:", "interpret:"],
+referencedClasses: ["Object", "BlockClosure"]
 }),
 smalltalk.ASTInterpreterTest);
 

--- a/js/Kernel-Infrastructure.js
+++ b/js/Kernel-Infrastructure.js
@@ -1684,6 +1684,28 @@ smalltalk.PlatformInterface.klass);
 
 smalltalk.addMethod(
 smalltalk.method({
+selector: "globalAt:",
+category: 'accessing',
+fn: function (aString){
+var self=this;
+return smalltalk.withContext(function($ctx1) { 
+
+	var f = new Function('aString',
+	'if (/^[0-9]/.test(aString) || !/^[\\w_]+$/.test(aString))\n'+
+	'	return undefined;\n'+
+	'try { return eval(aString); } catch (ex) {}\n'+
+	'return undefined;');
+	return f(aString);;
+return self}, function($ctx1) {$ctx1.fill(self,"globalAt:",{aString:aString},smalltalk.PlatformInterface.klass)})},
+args: ["aString"],
+source: "globalAt: aString\x0a<\x0a\x09var f = new Function('aString',\x0a\x09'if (/^[0-9]/.test(aString) || !/^[\x5c\x5cw_]+$/.test(aString))\x5cn'+\x0a\x09'\x09return undefined;\x5cn'+\x0a\x09'try { return eval(aString); } catch (ex) {}\x5cn'+\x0a\x09'return undefined;');\x0a\x09return f(aString);\x0a>",
+messageSends: [],
+referencedClasses: []
+}),
+smalltalk.PlatformInterface.klass);
+
+smalltalk.addMethod(
+smalltalk.method({
 selector: "initialize",
 category: 'initialization',
 fn: function (){

--- a/st/Compiler-Interpreter.st
+++ b/st/Compiler-Interpreter.st
@@ -336,7 +336,7 @@ interpretClassReferenceNode: aNode continue: aBlock
 		continue: aBlock 
 		value: (Smalltalk current 
 			at: aNode value
-			ifAbsent: [ window at: aNode value ])
+			ifAbsent: [ PlatformInterface globalAt: aNode value ])
 !
 
 interpretDynamicArrayNode: aNode continue: aBlock
@@ -404,7 +404,7 @@ interpretVariableNode: aNode continue: aBlock
 			ifTrue: [ self context receiver instVarAt: aNode value ]
 			ifFalse: [ self context 
 				localAt: aNode value 
-				ifAbsent: [ window at: aNode value ]])
+				ifAbsent: [ PlatformInterface globalAt: aNode value ]])
 ! !
 
 !ASTInterpreter methodsFor: 'private'!

--- a/st/Compiler-Tests.st
+++ b/st/Compiler-Tests.st
@@ -195,13 +195,6 @@ testInstVarAssignment
 		equals: 2
 !
 
-testJSGlobalVarAccess
-	"Capital letter variables are treated differently."
-	
-	self assert: (self interpret: 'foo ^ Math cos: 0') equals: 1.
-	self assert: (self interpret: 'foo ^ document title isString') equals: true.
-!
-
 testNonlocalReturn
 	self assert: (self interpret: 'foo true ifTrue: [ ^ 1 ]. ^2') equals: 1
 !
@@ -234,8 +227,11 @@ testThisContext
 	self assert: (self interpret: 'foo ^ [ thisContext ] value outerContext == thisContext')
 !
 
-testClassRefVarAccess
+testVariableAccess
 	self assert: (self interpret: 'foo ^ Object') equals: Object.
+	self assert: (self interpret: 'foo ^ Math cos: 0') equals: 1.
+	self assert: (self interpret: 'foo ^ eval class') equals: BlockClosure.
+	self assert: (self interpret: 'foo ^ NonExistingVar') equals: nil.
 ! !
 
 AbstractASTInterpreterTest subclass: #ASTSteppingInterpreterTest

--- a/st/Kernel-Infrastructure.st
+++ b/st/Kernel-Infrastructure.st
@@ -630,6 +630,17 @@ PlatformInterface class instanceVariableNames: 'worker'!
 
 setWorker: anObject
 	worker := anObject
+!
+
+globalAt: aString
+<
+	var f = new Function('aString',
+	'if (/^[0-9]/.test(aString) || !!/^[\\w_]+$/.test(aString))\n'+
+	'	return undefined;\n'+
+	'try { return eval(aString); } catch (ex) {}\n'+
+	'return undefined;');
+	return f(aString);
+>
 ! !
 
 !PlatformInterface class methodsFor: 'actions'!


### PR DESCRIPTION
This is a fix for #654.
