### PR TITLE
Grunt: '-v'/'--verbose' cmd line flag now makes compiler output verbose (fix #653)

### DIFF
--- a/grunt/tasks/grunt-amberc.js
+++ b/grunt/tasks/grunt-amberc.js
@@ -35,7 +35,7 @@ module.exports = function(grunt) {
     var options = this.options({
       amber_dir: undefined,
       closure_jar: '',
-      verbose: false
+      verbose: grunt.option('verbose') || false
     });
     this.data.verbose = options.verbose;
 


### PR DESCRIPTION
After this pullrequest is merged it will be possible to append `-v` or `--verbose` to the commandline flags when executing Grunt.
This will set the global verbose level of the compiler to `true`.
