### PR TITLE
test/Gruntfile.js : Run amber_test_runner directly from grunt via a spawned process.

### DIFF
--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+Test.js

--- a/test/Gruntfile.js
+++ b/test/Gruntfile.js
@@ -1,8 +1,9 @@
 module.exports = function(grunt) {
+
+  grunt.loadNpmTasks('grunt-contrib-watch');
   grunt.loadTasks('../grunt/tasks/');
-
-  grunt.registerTask('default', ['amberc:amber_test_runner','nodetest:all']);
-
+  grunt.loadNpmTasks('grunt-newer');  
+  grunt.registerTask('default', ['watch']);
   grunt.registerMultiTask('nodetest', 'Run a sub-gruntfile.', function() {
     var path = require('path');
     grunt.util.async.forEachSeries(this.filesSrc, function(nodefile, next) {
@@ -20,8 +21,11 @@ module.exports = function(grunt) {
       });
     }, this.async());
   });
+
+
+  var srcFiles = "Test.st";
   
-  grunt.initConfig({
+  grunt.config.init({
     nodetest: {
         all: {
             files: {src:['amber_test_runner.js']} 
@@ -30,18 +34,24 @@ module.exports = function(grunt) {
     amberc: {
         options: {
             amber_dir: '../',
-            closure_jar: '',
-            verbose: true
+            closure_jar: ''
         },
 
-        amber_test_runner: {            
+        all: {            
             libraries: [
                 'Compiler-Exceptions', 'Compiler-Core', 'Compiler-AST',
                 'Compiler-IR', 'Compiler-Inlining', 'Compiler-Semantic', 'Compiler-Interpreter', '@parser',
                 'SUnit', 'Importer-Exporter',
                 'Kernel-Tests', 'Compiler-Tests', 'SUnit-Tests'],
             output_name: 'amber_test_runner',                                         
-            src: ['Test.st']
+            src: [srcFiles]
         }
-    }});
+    },
+    watch: {
+        all: {
+            files: srcFiles,
+            tasks:['any-newer:amberc:all','nodetest:all']
+        }
+    }
+    });
 };

--- a/test/package.json
+++ b/test/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "amber-test",
+  "version": "0.0.0",
+  "description": "Testing for amber.",
+  "homepage": "http://amber-lang.net",
+  "keywords": [
+    "javascript",
+    "smalltalk",
+    "language",
+    "compiler",
+    "web"
+  ],
+  "author": {
+    "name": "Nicolas Petton",
+    "email": "petton.nicolas@gmail.com",
+    "url": "http://www.nicolas-petton.fr"
+  },
+  "license": {
+    "type": "MIT"
+  },
+  "scripts": {
+    "test": "grunt"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/amber-smalltalk/amber.git"
+  },
+  "engines": {
+    "node": ">=0.8.0"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "grunt": ">=0.4.1",
+    "grunt-cli": "0.1.9",
+    "grunt-contrib-jshint": "~0.3.0",
+    "amdefine": "0.0.8",
+    "grunt-newer": ">=0.5.1",
+    "grunt-contrib-watch": ">=0.5.3"
+  }
+}


### PR DESCRIPTION
This 47 line Gruntfile.js  by default will:

1) compiles test/Test.st to test/amber_test_runner.js
2) runs all the tests by executing `node test/amber_test_runner.js` from  a spawned context.

Once amber_test_runner.js can been compiled  `grunt nodetest:all` will run all the tests without a compile.

If can build it with grunt you can execute it without a wrapper.
