### PR TITLE
Testing for grunt-amberc.js and verbose_tests case gruntfile.

### DIFF
--- a/grunt/tasks/grunt-amberc.js
+++ b/grunt/tasks/grunt-amberc.js
@@ -47,7 +47,22 @@ module.exports = function(grunt) {
 
     // generate the amberc configuration out of the given target properties
     var configuration = generateCompilerConfiguration(this.data, grunt.config('amberc.options.amber_dir'));
-
+    if (typeof(configuration.test_return) == 'function') {
+        // When test_return is a function call to preempt compile.main(configuration) function.
+        // Call test_return(configuration) with the configuration passed to compiler.main()
+        // preempt means we never really call compiler.main().
+        grunt.util.hooker.hook(compiler,"main", {
+            pre: function() {
+                if (typeof(arguments[0]) !== 'undefined') {
+                    configuration.test_return(arguments[0]);
+                }
+                if (typeof(arguments[1]) === 'function') {
+                    arguments[1]();
+                }
+                return grunt.util.hooker.preempt();
+            }
+        });
+    }
     // run the compiler and call the async callback once finished
     var self = this;
     compiler.main(configuration, function(){
@@ -60,7 +75,7 @@ module.exports = function(grunt) {
   function generateCompilerConfiguration(data, amber_dir) {
     var configuration = amberc.createDefaults(amber_dir);
     var parameters = [];
-
+    configuration.test_return = data.test_return;
     var libraries = data.libraries;
     if (undefined !== libraries) {
       configuration.load = libraries;

--- a/grunt/test/testcases/README.md
+++ b/grunt/test/testcases/README.md
@@ -1,0 +1,7 @@
+### This directory is for files that test grunt tasks
+
+To run a test
+
+    grunt --gruntfile verbose_tests.js
+
+For these tests a non successful exit of grunt means an error.

--- a/grunt/test/testcases/verbose_tests.js
+++ b/grunt/test/testcases/verbose_tests.js
@@ -1,0 +1,34 @@
+module.exports = function(grunt) {
+  grunt.loadTasks('../../tasks/');
+
+  grunt.registerTask('default',['amberc']);
+  
+  var assert = require('assert');
+
+  grunt.initConfig({
+
+    amberc: {
+        options: {
+            amber_dir: '../../../',
+            closure_jar: '',
+            verbose: 1, // Override built in setting to 1
+            printConfigAndStop: true
+        },
+        test1: { // Test task options setting
+            src: ['./Gruntfile.js'],
+            test_return: function(value) {assert(value.verbose == 1,"verbose (set by task options) should be 1!");},
+        },
+        test2: { // Test target options setting
+            options: {verbose: 2}, // Set it here to 2
+            src: ['./Gruntfile.js'],
+            test_return: function(value) {assert(value.verbose == 2,"verbose (set by target options) should be 2!");},
+        },
+        test3: { // Test target as a property setting
+            verbose: 3, // Set it here to 3
+            src: ['./Gruntfile.js'],
+            test_return: function(value) {assert(value.verbose == 3,"verbose set by target property should be 3!");},
+        }   
+    }
+    
+    });
+};


### PR DESCRIPTION
This is the best and least intrusive method I have found to debug and test the grunt-amberc.js task. This method has critics because it is not "outside the task". I would welcome a method like that but until that method is presented lets debug and test with this method. This method can be stripped from the code when all bugs are removed from the code which is likely never.

I also include testcases/verbose_tests.js you do the tests by:

```
grunt --gruntfile verbose_tests.js
```

This test has a critic that objects to the use of integer values 1,2 and 3 in this test for boolean values. I respond, that this is testing and javascript coerces integer 0 to false and all other to true.

To write new tests write a similar gruntfile with a amber.test_return set to a function(configuration) { test the config}
