### PR TITLE
change locating the bower_components directory in amber.js

### DIFF
--- a/support/amber.js
+++ b/support/amber.js
@@ -17,7 +17,13 @@ var require;
 require = function (require) {
     var scripts = document.getElementsByTagName("script");
     var src = scripts[ scripts.length - 1 ].src;
-    var home = resolveViaDOM(src).replace(/\/[^\/]+\/[^\/]+$/, "");
+    // strip the last two elements from the URL
+    // e.g. http://app.com/lib/script.js -> http://app.com/
+    var amber_home = resolveViaDOM(src).replace(/\/[^\/]+\/[^\/]+$/, "");
+    // strip the last element from the URL
+    // e.g. http://app.com/index.html -> http://app.com/
+    var document_home = window.location.href.replace(/\/[^\/]+$/, "");
+
 
     function resolveViaDOM(url) {
         var a = document.createElement("a");
@@ -27,16 +33,16 @@ require = function (require) {
 
     var config = {
         paths: {
-            'amber': home+'/support',
-            'amber_vm': home+'/support',
-            'amber_css': home+'/css',
-            'amber_lib': home+'/bower_components',
-            'amber_inc': home+'/support',
-            'amber_core': home+'/js',
-            'amber_core/_source': home+'/st',
-            'amber_html': home,
-            'jquery': home+'/bower_components/jquery/jquery.min',
-            'jquery-ui': home+'/support/jQuery/jquery-ui-1.8.24.custom.min'
+            'amber': amber_home + '/support',
+            'amber_vm': amber_home + '/support',
+            'amber_css': amber_home + '/css',
+            'amber_lib': document_home + '/bower_components',
+            'amber_inc': amber_home + '/support',
+            'amber_core': amber_home + '/js',
+            'amber_core/_source': amber_home + '/st',
+            'amber_html': amber_home,
+            'jquery': document_home + '/bower_components/jquery/jquery.min',
+            'jquery-ui': amber_home + '/support/jQuery/jquery-ui-1.8.24.custom.min'
         },
         map: {
             '*': {


### PR DESCRIPTION
The bower_components directory is usually found in the root directory of the application.
However, it is not necessarily found in the Amber directory.

Usecase:
1. create new project
2. run 'bower init'
3. run 'bower install --save amber#master' // use master for the requirejs stuff
4. create index.html and load Amber via

```
    <script type='text/javascript' src='bower_components/amber/support/amber.js'></script>
    <script type='text/javascript' src='bower_components/amber/support/requirejs/require.min.js'></script>
```
1. load index.html via a file:/// url

Without this change all bower components will get searched in
file:///project_dir/bower_components/amber/bower_components/.
With this change dependent files are loaded correctly.
