### PR TITLE
Added support for white space preceding class definitions

### DIFF
--- a/js/Helios-Core.js
+++ b/js/Helios-Core.js
@@ -1050,12 +1050,12 @@ return smalltalk.withContext(function($ctx1) {
 var $1;
 $1=_st(_st(self._selectedClass())._isNil())._or_((function(){
 return smalltalk.withContext(function($ctx2) {
-return _st(aString)._match_("^[A-Z]");
+return _st(aString)._match_("^\x5cs*[A-Z]");
 }, function($ctx2) {$ctx2.fillBlock({},$ctx1,1)})}));
 return $1;
 }, function($ctx1) {$ctx1.fill(self,"shouldCompileClassDefinition:",{aString:aString},smalltalk.HLToolModel)})},
 args: ["aString"],
-source: "shouldCompileClassDefinition: aString\x0a\x09^ self selectedClass isNil or: [\x0a\x09\x09aString match: '^[A-Z]' ]",
+source: "shouldCompileClassDefinition: aString\x0a\x09^ self selectedClass isNil or: [\x0a\x09\x09aString match: '^\x5cs*[A-Z]' ]",
 messageSends: ["or:", "isNil", "selectedClass", "match:"],
 referencedClasses: []
 }),

--- a/st/Helios-Core.st
+++ b/st/Helios-Core.st
@@ -392,7 +392,7 @@ isToolModel
 
 shouldCompileClassDefinition: aString
 	^ self selectedClass isNil or: [
-		aString match: '^[A-Z]' ]
+		aString match: '^\s*[A-Z]' ]
 ! !
 
 !HLToolModel class methodsFor: 'actions'!


### PR DESCRIPTION
Further to  amber-smalltalk/amber#721, ignoring white space preceding class names in `shouldCompileClassDefinition:`.
