### PR TITLE
SystemAnnouncement: remove theClass instance variable + accessors

### DIFF
--- a/js/Kernel-Announcements.js
+++ b/js/Kernel-Announcements.js
@@ -367,42 +367,8 @@ referencedClasses: []
 smalltalk.SystemAnnouncer.klass);
 
 
-smalltalk.addClass('SystemAnnouncement', smalltalk.Object, ['theClass'], 'Kernel-Announcements');
+smalltalk.addClass('SystemAnnouncement', smalltalk.Object, [], 'Kernel-Announcements');
 smalltalk.SystemAnnouncement.comment="I am the superclass of all system announcements";
-smalltalk.addMethod(
-smalltalk.method({
-selector: "theClass",
-category: 'accessing',
-fn: function (){
-var self=this;
-return smalltalk.withContext(function($ctx1) { 
-var $1;
-$1=self["@theClass"];
-return $1;
-}, function($ctx1) {$ctx1.fill(self,"theClass",{},smalltalk.SystemAnnouncement)})},
-args: [],
-source: "theClass\x0a\x09^ theClass",
-messageSends: [],
-referencedClasses: []
-}),
-smalltalk.SystemAnnouncement);
-
-smalltalk.addMethod(
-smalltalk.method({
-selector: "theClass:",
-category: 'accessing',
-fn: function (aClass){
-var self=this;
-return smalltalk.withContext(function($ctx1) { 
-self["@theClass"]=aClass;
-return self}, function($ctx1) {$ctx1.fill(self,"theClass:",{aClass:aClass},smalltalk.SystemAnnouncement)})},
-args: ["aClass"],
-source: "theClass: aClass\x0a\x09theClass := aClass",
-messageSends: [],
-referencedClasses: []
-}),
-smalltalk.SystemAnnouncement);
-
 
 smalltalk.addMethod(
 smalltalk.method({

--- a/st/Kernel-Announcements.st
+++ b/st/Kernel-Announcements.st
@@ -157,20 +157,10 @@ new
 ! !
 
 Object subclass: #SystemAnnouncement
-	instanceVariableNames: 'theClass'
+	instanceVariableNames: ''
 	package: 'Kernel-Announcements'!
 !SystemAnnouncement commentStamp!
 I am the superclass of all system announcements!
-
-!SystemAnnouncement methodsFor: 'accessing'!
-
-theClass
-	^ theClass
-!
-
-theClass: aClass
-	theClass := aClass
-! !
 
 !SystemAnnouncement class methodsFor: 'helios'!
 


### PR DESCRIPTION
Both ClassAnnouncement and ProtocolAnnouncement contain the same instance variable + accessors.
The instance variable is removed from SystemAnnouncement since it does not generalize for all Announcement subclasses.
