### PR TITLE
Fix String>>, bug in Chrome dev

### DIFF
--- a/js/Kernel-Collections.js
+++ b/js/Kernel-Collections.js
@@ -3726,10 +3726,10 @@ category: 'copying',
 fn: function (aString){
 var self=this;
 return smalltalk.withContext(function($ctx1) { 
-return String(self) + aString._asString();
+return String(self) + aString;
 return self}, function($ctx1) {$ctx1.fill(self,",",{aString:aString},smalltalk.String)})},
 args: ["aString"],
-source: ", aString\x0a\x09<return String(self) + aString._asString()>",
+source: ", aString\x0a\x09<return String(self) + aString>",
 messageSends: [],
 referencedClasses: []
 }),

--- a/st/Kernel-Collections.st
+++ b/st/Kernel-Collections.st
@@ -1401,7 +1401,7 @@ uriEncoded
 !String methodsFor: 'copying'!
 
 , aString
-	<return String(self) + aString._asString()>
+	<return String(self) + aString>
 !
 
 copyFrom: anIndex to: anotherIndex


### PR DESCRIPTION
In the latest developer builds of Chrome for Windows (e.g. Version 33.0.1726.0 dev-m, or Canary,) String>>, (comma) sometimes throws a JavascriptError: Illegal access (you can see this in action evaluating '0 halt' in an Helios Workspace, for example).

The problem doesn't show up in the stable version of Chrome, nor in other browser I regularly use (Firefox, Safari, Explorer).

This is fixed explicitly "stringifying" both self and the parameter before concatenation.
By the way, similar methods in String already use this policy (see String>><, String>>=,...)

max
