### PR TITLE
More restrictive symbol matching

### DIFF
--- a/support/CodeMirror/smalltalk.js
+++ b/support/CodeMirror/smalltalk.js
@@ -35,8 +35,8 @@ CodeMirror.defineMode('smalltalk', function(config, modeConfig) {
 		} else if (aChar === '\'') {
 			token = nextString(stream, new Context(nextString, context));
 
-		} else if (aChar === '#') {
-			stream.eatWhile(/[^ .]/);
+		} else if (aChar === '#' && !/[{(]/.test(stream.peek())) {
+			stream.eatWhile(/[^ .\]})]/);
 			token.name = 'string-2';
 
 		} else if (aChar === '$') {


### PR DESCRIPTION
This change prevents brackets in collection literals from matching symbols so things that care (such as bracket matching via CodeMirror in the source code editor) can see them more easily.

As far as I can tell, there are no unit tests for the existing code, hence no unit tests for this change. The existing SUnit tests pass. I have tested this change manually.
