### PR TITLE
Allow one to click on methods in the browser

### DIFF
--- a/src/Helios-Browser.js
+++ b/src/Helios-Browser.js
@@ -3201,11 +3201,11 @@ protocol: 'actions',
 fn: function (anItem){
 var self=this;
 return smalltalk.withContext(function($ctx1) { 
-_st(self._model())._forceSelectedMethod_(anItem);
+_st(self._model())._forceSelectedMethod_(self._methodForSelector_(anItem));
 return self}, function($ctx1) {$ctx1.fill(self,"reselectItem:",{anItem:anItem},globals.HLMethodsListWidget)})},
 args: ["anItem"],
-source: "reselectItem: anItem\x0a\x09self model forceSelectedMethod: anItem",
-messageSends: ["forceSelectedMethod:", "model"],
+source: "reselectItem: anItem\x0a\x09self model forceSelectedMethod: (self methodForSelector: anItem)",
+messageSends: ["forceSelectedMethod:", "model", "methodForSelector:"],
 referencedClasses: []
 }),
 globals.HLMethodsListWidget);

--- a/src/Helios-Browser.st
+++ b/src/Helios-Browser.st
@@ -1012,7 +1012,7 @@ observeSystem
 !
 
 reselectItem: anItem
-	self model forceSelectedMethod: anItem
+	self model forceSelectedMethod: (self methodForSelector: anItem)
 !
 
 selectItem: aSelector


### PR DESCRIPTION
`HLModelsListWidget` has been sending a `String` to `HLToolModel#forceSelectedMethod:` and not a `CompiledMethod` like it expects. This causes a debugger to open every time I try to click on a method in the Browser. This PR makes `HLModelsListWidget#reselectItem:` send a `CompiledMethod` to `HLToolModel#forceSelectedMethod:`.
