### PR TITLE
Issue 962: Use Symbol's implementation of String>>#value:

### DIFF
--- a/src/Kernel-Collections.js
+++ b/src/Kernel-Collections.js
@@ -5236,6 +5236,24 @@ referencedClasses: []
 }),
 globals.String);
 
+smalltalk.addMethod(
+smalltalk.method({
+selector: "value:",
+protocol: 'evaluating',
+fn: function (anObject){
+var self=this;
+return smalltalk.withContext(function($ctx1) { 
+var $1;
+$1=_st(anObject)._perform_(self);
+return $1;
+}, function($ctx1) {$ctx1.fill(self,"value:",{anObject:anObject},globals.String)})},
+args: ["anObject"],
+source: "value: anObject \x0a\x09^ anObject perform: self",
+messageSends: ["perform:"],
+referencedClasses: []
+}),
+globals.String);
+
 
 smalltalk.addMethod(
 smalltalk.method({

--- a/src/Kernel-Collections.st
+++ b/src/Kernel-Collections.st
@@ -1597,6 +1597,12 @@ shallowCopy
 	^ self class fromString: self
 ! !
 
+!String methodsFor: 'evaluating'!
+
+value: anObject 
+	^ anObject perform: self
+! !
+
 !String methodsFor: 'printing'!
 
 printNl

--- a/src/Kernel-Tests.js
+++ b/src/Kernel-Tests.js
@@ -5200,6 +5200,24 @@ referencedClasses: []
 }),
 globals.StringTest);
 
+smalltalk.addMethod(
+smalltalk.method({
+selector: "testValue",
+protocol: 'tests',
+fn: function (){
+var self=this;
+return smalltalk.withContext(function($ctx1) { 
+self._assert_equals_("asString"._value_((1)),"1");
+$ctx1.sendIdx["assert:equals:"]=1;
+self._assert_equals_([(1), (2), (3)]._collect_("asString"),["1", "2", "3"]);
+return self}, function($ctx1) {$ctx1.fill(self,"testValue",{},globals.StringTest)})},
+args: [],
+source: "testValue\x0a\x0a\x09self assert: (#asString value: 1) equals: '1'.\x0a\x0a\x09\x22Which (since String and BlockClosure are now polymorphic) enables the nice idiom...\x22\x0a\x09self assert: (#(1 2 3) collect: #asString) equals: #('1' '2' '3')",
+messageSends: ["assert:equals:", "value:", "collect:"],
+referencedClasses: []
+}),
+globals.StringTest);
+
 
 smalltalk.addMethod(
 smalltalk.method({

--- a/src/Kernel-Tests.st
+++ b/src/Kernel-Tests.st
@@ -1498,6 +1498,14 @@ testSubStrings
 testTrim
 	self assert: '       jackie' trimLeft equals: 'jackie'.
 	self assert: 'jackie               ' trimRight equals: 'jackie'.
+!
+
+testValue
+
+	self assert: (#asString value: 1) equals: '1'.
+
+	"Which (since String and BlockClosure are now polymorphic) enables the nice idiom..."
+	self assert: (#(1 2 3) collect: #asString) equals: #('1' '2' '3')
 ! !
 
 !StringTest class methodsFor: 'fixture'!


### PR DESCRIPTION
- Implement String>>#value:
- Add tests
