### PR TITLE
Allow amberdir per task

### DIFF
--- a/external/amber-dev/tasks/grunt-amberc.js
+++ b/external/amber-dev/tasks/grunt-amberc.js
@@ -60,7 +60,7 @@ module.exports = function(grunt) {
     }
 
     // create and initialize amberc
-    var compiler = new amberc.Compiler(grunt.config('amberc.options.amber_dir'));
+    var compiler = new amberc.Compiler(options.amber_dir);
 
     // generate the amberc configuration out of the given target properties
     var configuration = generateCompilerConfiguration(this.data, this.filesSrc);


### PR DESCRIPTION
Allows amber_dir setting per task to be actually honoured.

For the moment, the task-local value of amber_dir is ignore and amberc.options.amber_dir is used.
