### PR TITLE
Imports outputted differently in .js files, fixes #1145 differently.

### DIFF
--- a/external/amber-dev/lib/amberc.js
+++ b/external/amber-dev/lib/amberc.js
@@ -361,6 +361,7 @@ function create_compiler(configuration) {
 			var match = ('' + data).match(/^define\("([^"]*)"/);
 			if (match) {
 				loadIds.push(match[1]);
+				builder.add('define("'+match[1]+'%Imports", {});\n');
 			}
 		});
 
@@ -560,6 +561,7 @@ function compose_js_files(configuration) {
 				var match = buffer.toString().match(/(^|\n)define\("([^"]*)"/);
 				if (match /*&& match[1].slice(0,9) !== "amber_vm/"*/) {
 					builder.addId(match[2]);
+					builder.add('define("'+match[2]+'%Imports", {});\n'); //TODO here, actual Imports file should be
 				}
 				builder.add(buffer);
 			} else {

--- a/external/amber-dev/package.json
+++ b/external/amber-dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amber-dev",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Development goodies for Amber Smalltalk",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/src/Kernel-ImportExport.js
+++ b/src/Kernel-ImportExport.js
@@ -2668,6 +2668,52 @@ $globals.PackageHandler);
 
 $core.addMethod(
 $core.method({
+selector: "commitFiles:toPathPrefix:onSuccess:onError:",
+protocol: 'committing',
+fn: function (aDictionary,aString,aBlock,anotherBlock){
+var self=this;
+//>>excludeStart("ctx", pragmas.excludeDebugContexts);
+return $core.withContext(function($ctx1) {
+//>>excludeEnd("ctx");
+$recv(aDictionary)._ifEmpty_ifNotEmpty_(aBlock,(function(){
+var ext,contents;
+//>>excludeStart("ctx", pragmas.excludeDebugContexts);
+return $core.withContext(function($ctx2) {
+//>>excludeEnd("ctx");
+ext=$recv($recv(aDictionary)._keys())._anyOne();
+ext;
+contents=$recv(aDictionary)._at_(ext);
+contents;
+return self._ajaxPutAt_data_onSuccess_onError_($recv(aString).__comma(ext),contents,(function(){
+//>>excludeStart("ctx", pragmas.excludeDebugContexts);
+return $core.withContext(function($ctx3) {
+//>>excludeEnd("ctx");
+$recv(aDictionary)._removeKey_(ext);
+return self._commitFiles_toPathPrefix_onSuccess_onError_(aDictionary,aString,aBlock,anotherBlock);
+//>>excludeStart("ctx", pragmas.excludeDebugContexts);
+}, function($ctx3) {$ctx3.fillBlock({},$ctx2,2)});
+//>>excludeEnd("ctx");
+}),anotherBlock);
+//>>excludeStart("ctx", pragmas.excludeDebugContexts);
+}, function($ctx2) {$ctx2.fillBlock({ext:ext,contents:contents},$ctx1,1)});
+//>>excludeEnd("ctx");
+}));
+return self;
+//>>excludeStart("ctx", pragmas.excludeDebugContexts);
+}, function($ctx1) {$ctx1.fill(self,"commitFiles:toPathPrefix:onSuccess:onError:",{aDictionary:aDictionary,aString:aString,aBlock:aBlock,anotherBlock:anotherBlock},$globals.PackageHandler)});
+//>>excludeEnd("ctx");
+},
+//>>excludeStart("ide", pragmas.excludeIdeData);
+args: ["aDictionary", "aString", "aBlock", "anotherBlock"],
+source: "commitFiles: aDictionary toPathPrefix: aString onSuccess: aBlock onError: anotherBlock\x0a\x09aDictionary ifEmpty: aBlock ifNotEmpty: [\x0a\x09\x09| ext contents |\x0a\x09\x09ext := aDictionary keys anyOne.\x0a\x09\x09contents := aDictionary at: ext.\x0a\x09\x09self \x0a\x09\x09\x09ajaxPutAt: aString, ext\x0a\x09\x09\x09\x09data: contents\x0a\x09\x09\x09\x09onSuccess: [\x0a\x09\x09\x09\x09\x09aDictionary removeKey: ext.\x0a\x09\x09\x09\x09\x09self\x0a\x09\x09\x09\x09\x09\x09commitFiles: aDictionary\x0a\x09\x09\x09\x09\x09\x09toPathPrefix: aString\x0a\x09\x09\x09\x09\x09\x09onSuccess: aBlock\x0a\x09\x09\x09\x09\x09\x09onError: anotherBlock ]\x0a\x09\x09\x09\x09onError: anotherBlock ]",
+referencedClasses: [],
+//>>excludeEnd("ide");
+messageSends: ["ifEmpty:ifNotEmpty:", "anyOne", "keys", "at:", "ajaxPutAt:data:onSuccess:onError:", ",", "removeKey:", "commitFiles:toPathPrefix:onSuccess:onError:"]
+}),
+$globals.PackageHandler);
+
+$core.addMethod(
+$core.method({
 selector: "commitJsFileFor:onSuccess:onError:",
 protocol: 'committing',
 fn: function (aPackage,aBlock,anotherBlock){
@@ -2675,16 +2721,13 @@ var self=this;
 //>>excludeStart("ctx", pragmas.excludeDebugContexts);
 return $core.withContext(function($ctx1) {
 //>>excludeEnd("ctx");
-var $2,$1;
+var $1,$2;
+$1=self._contentsFor_(aPackage);
 $2=$recv($recv(self._commitPathJsFor_(aPackage)).__comma("/")).__comma($recv(aPackage)._name());
-//>>excludeStart("ctx", pragmas.excludeDebugContexts);
-$ctx1.sendIdx[","]=2;
-//>>excludeEnd("ctx");
-$1=$recv($2).__comma(".js");
 //>>excludeStart("ctx", pragmas.excludeDebugContexts);
 $ctx1.sendIdx[","]=1;
 //>>excludeEnd("ctx");
-self._ajaxPutAt_data_onSuccess_onError_($1,self._contentsFor_(aPackage),aBlock,anotherBlock);
+self._commitFiles_toPathPrefix_onSuccess_onError_($1,$2,aBlock,anotherBlock);
 return self;
 //>>excludeStart("ctx", pragmas.excludeDebugContexts);
 }, function($ctx1) {$ctx1.fill(self,"commitJsFileFor:onSuccess:onError:",{aPackage:aPackage,aBlock:aBlock,anotherBlock:anotherBlock},$globals.PackageHandler)});
@@ -2692,10 +2735,10 @@ return self;
 },
 //>>excludeStart("ide", pragmas.excludeIdeData);
 args: ["aPackage", "aBlock", "anotherBlock"],
-source: "commitJsFileFor: aPackage onSuccess: aBlock onError: anotherBlock\x0a\x09self \x0a\x09\x09ajaxPutAt: (self commitPathJsFor: aPackage), '/', aPackage name, '.js'\x0a\x09\x09data: (self contentsFor: aPackage)\x0a\x09\x09onSuccess: aBlock\x0a\x09\x09onError: anotherBlock",
+source: "commitJsFileFor: aPackage onSuccess: aBlock onError: anotherBlock\x0a\x09self\x0a\x09\x09commitFiles: (self contentsFor: aPackage)\x0a\x09\x09toPathPrefix: (self commitPathJsFor: aPackage), '/', aPackage name\x0a\x09\x09onSuccess: aBlock\x0a\x09\x09onError: anotherBlock",
 referencedClasses: [],
 //>>excludeEnd("ide");
-messageSends: ["ajaxPutAt:data:onSuccess:onError:", ",", "commitPathJsFor:", "name", "contentsFor:"]
+messageSends: ["commitFiles:toPathPrefix:onSuccess:onError:", "contentsFor:", ",", "commitPathJsFor:", "name"]
 }),
 $globals.PackageHandler);
 
@@ -2786,12 +2829,14 @@ selector: "contentsFor:",
 protocol: 'accessing',
 fn: function (aPackage){
 var self=this;
+function $Dictionary(){return $globals.Dictionary||(typeof Dictionary=="undefined"?nil:Dictionary)}
 function $String(){return $globals.String||(typeof String=="undefined"?nil:String)}
 //>>excludeStart("ctx", pragmas.excludeDebugContexts);
 return $core.withContext(function($ctx1) {
 //>>excludeEnd("ctx");
-var $1;
-$1=$recv($String())._streamContents_((function(str){
+var $2,$3,$1;
+$2=$recv($Dictionary())._new();
+$recv($2)._at_put_(".js",$recv($String())._streamContents_((function(str){
 //>>excludeStart("ctx", pragmas.excludeDebugContexts);
 return $core.withContext(function($ctx2) {
 //>>excludeEnd("ctx");
@@ -2799,7 +2844,9 @@ return $recv(self._exporter())._exportPackage_on_(aPackage,str);
 //>>excludeStart("ctx", pragmas.excludeDebugContexts);
 }, function($ctx2) {$ctx2.fillBlock({str:str},$ctx1,1)});
 //>>excludeEnd("ctx");
-}));
+})));
+$3=$recv($2)._yourself();
+$1=$3;
 return $1;
 //>>excludeStart("ctx", pragmas.excludeDebugContexts);
 }, function($ctx1) {$ctx1.fill(self,"contentsFor:",{aPackage:aPackage},$globals.PackageHandler)});
@@ -2807,10 +2854,10 @@ return $1;
 },
 //>>excludeStart("ide", pragmas.excludeIdeData);
 args: ["aPackage"],
-source: "contentsFor: aPackage\x0a\x09^ String streamContents: [ :str |\x0a\x09\x09self exporter exportPackage: aPackage on: str ]",
-referencedClasses: ["String"],
+source: "contentsFor: aPackage\x0a\x09^ Dictionary new\x0a\x09\x09at: '.js' put: (String streamContents: [ :str |\x0a\x09\x09\x09self exporter exportPackage: aPackage on: str ]);\x0a\x09\x09yourself",
+referencedClasses: ["Dictionary", "String"],
 //>>excludeEnd("ide");
-messageSends: ["streamContents:", "exportPackage:on:", "exporter"]
+messageSends: ["at:put:", "new", "streamContents:", "exportPackage:on:", "exporter", "yourself"]
 }),
 $globals.PackageHandler);
 

--- a/src/Kernel-ImportExport.js
+++ b/src/Kernel-ImportExport.js
@@ -1607,6 +1607,24 @@ $globals.Exporter);
 
 $core.addMethod(
 $core.method({
+selector: "exportPackageImportsFileOf:on:",
+protocol: 'output',
+fn: function (aPackage,aStream){
+var self=this;
+return self;
+
+},
+//>>excludeStart("ide", pragmas.excludeIdeData);
+args: ["aPackage", "aStream"],
+source: "exportPackageImportsFileOf: aPackage on: aStream\x0a\x09\x22do nothing\x22",
+referencedClasses: [],
+//>>excludeEnd("ide");
+messageSends: []
+}),
+$globals.Exporter);
+
+$core.addMethod(
+$core.method({
 selector: "exportPackageImportsOf:on:",
 protocol: 'output',
 fn: function (aPackage,aStream){
@@ -1950,40 +1968,180 @@ $globals.AmdExporter);
 
 $core.addMethod(
 $core.method({
-selector: "exportPackagePrologueOf:on:",
+selector: "exportPackageImportsFileOf:on:",
 protocol: 'output',
 fn: function (aPackage,aStream){
 var self=this;
-var namedImports,anonImports,importVarNames,loadDependencies;
 //>>excludeStart("ctx", pragmas.excludeDebugContexts);
 return $core.withContext(function($ctx1) {
 //>>excludeEnd("ctx");
-var $1,$5,$4,$3,$2,$6;
-namedImports=[];
-anonImports=[];
-importVarNames=[];
-$recv($recv(aPackage)._imports())._do_((function(each){
+var $1,$2,$3,$4,$5;
+$recv($recv(aPackage)._imports())._ifNotEmpty_((function(){
+var namedImports,anonImports,importVarNames;
 //>>excludeStart("ctx", pragmas.excludeDebugContexts);
 return $core.withContext(function($ctx2) {
+//>>excludeEnd("ctx");
+namedImports=[];
+namedImports;
+anonImports=[];
+anonImports;
+importVarNames=[];
+importVarNames;
+$recv($recv(aPackage)._sortedImportsAsArray())._do_((function(each){
+//>>excludeStart("ctx", pragmas.excludeDebugContexts);
+return $core.withContext(function($ctx3) {
 //>>excludeEnd("ctx");
 $1=$recv(each)._isString();
 if($core.assert($1)){
 return $recv(anonImports)._add_(each);
 //>>excludeStart("ctx", pragmas.excludeDebugContexts);
-$ctx2.sendIdx["add:"]=1;
+$ctx3.sendIdx["add:"]=1;
 //>>excludeEnd("ctx");
 } else {
 $recv(namedImports)._add_($recv(each)._value());
 //>>excludeStart("ctx", pragmas.excludeDebugContexts);
-$ctx2.sendIdx["add:"]=2;
+$ctx3.sendIdx["add:"]=2;
 //>>excludeEnd("ctx");
 return $recv(importVarNames)._add_($recv(each)._key());
 };
 //>>excludeStart("ctx", pragmas.excludeDebugContexts);
-}, function($ctx2) {$ctx2.fillBlock({each:each},$ctx1,1)});
+}, function($ctx3) {$ctx3.fillBlock({each:each},$ctx2,2)});
 //>>excludeEnd("ctx");
 }));
+$recv(aStream)._nextPutAll_("define(\x22");
+//>>excludeStart("ctx", pragmas.excludeDebugContexts);
+$ctx2.sendIdx["nextPutAll:"]=1;
+//>>excludeEnd("ctx");
+$recv(aStream)._nextPutAll_(self._amdNamespaceOfPackage_(aPackage));
+//>>excludeStart("ctx", pragmas.excludeDebugContexts);
+$ctx2.sendIdx["nextPutAll:"]=2;
+//>>excludeEnd("ctx");
+$recv(aStream)._nextPutAll_("/");
+//>>excludeStart("ctx", pragmas.excludeDebugContexts);
+$ctx2.sendIdx["nextPutAll:"]=3;
+//>>excludeEnd("ctx");
+$recv(aStream)._nextPutAll_($recv(aPackage)._name());
+//>>excludeStart("ctx", pragmas.excludeDebugContexts);
+$ctx2.sendIdx["nextPutAll:"]=4;
+//>>excludeEnd("ctx");
+$recv(aStream)._nextPutAll_("%Imports\x22, ");
+//>>excludeStart("ctx", pragmas.excludeDebugContexts);
+$ctx2.sendIdx["nextPutAll:"]=5;
+//>>excludeEnd("ctx");
+$recv(aStream)._nextPutAll_($recv($recv(namedImports).__comma(anonImports))._asJavascript());
+//>>excludeStart("ctx", pragmas.excludeDebugContexts);
+$ctx2.sendIdx["nextPutAll:"]=6;
+//>>excludeEnd("ctx");
+$recv(aStream)._nextPutAll_(", function(");
+//>>excludeStart("ctx", pragmas.excludeDebugContexts);
+$ctx2.sendIdx["nextPutAll:"]=7;
+//>>excludeEnd("ctx");
+$recv(aStream)._nextPutAll_($recv(importVarNames)._join_(","));
+//>>excludeStart("ctx", pragmas.excludeDebugContexts);
+$ctx2.sendIdx["nextPutAll:"]=8;
+//>>excludeEnd("ctx");
+$recv(aStream)._nextPutAll_("){");
+//>>excludeStart("ctx", pragmas.excludeDebugContexts);
+$ctx2.sendIdx["nextPutAll:"]=9;
+//>>excludeEnd("ctx");
+$recv(aStream)._lf();
+//>>excludeStart("ctx", pragmas.excludeDebugContexts);
+$ctx2.sendIdx["lf"]=1;
+//>>excludeEnd("ctx");
+$recv(aStream)._nextPutAll_("return {");
+//>>excludeStart("ctx", pragmas.excludeDebugContexts);
+$ctx2.sendIdx["nextPutAll:"]=10;
+//>>excludeEnd("ctx");
+$2=$recv(aStream)._lf();
+//>>excludeStart("ctx", pragmas.excludeDebugContexts);
+$ctx2.sendIdx["lf"]=2;
+//>>excludeEnd("ctx");
+$2;
+$recv(importVarNames)._do_separatedBy_((function(each){
+//>>excludeStart("ctx", pragmas.excludeDebugContexts);
+return $core.withContext(function($ctx3) {
+//>>excludeEnd("ctx");
+$recv(aStream)._tab();
+$recv(aStream)._nextPutAll_(each);
+//>>excludeStart("ctx", pragmas.excludeDebugContexts);
+$ctx3.sendIdx["nextPutAll:"]=11;
+//>>excludeEnd("ctx");
+$recv(aStream)._nextPutAll_(": ");
+//>>excludeStart("ctx", pragmas.excludeDebugContexts);
+$ctx3.sendIdx["nextPutAll:"]=12;
+//>>excludeEnd("ctx");
+$3=$recv(aStream)._nextPutAll_(each);
+//>>excludeStart("ctx", pragmas.excludeDebugContexts);
+$ctx3.sendIdx["nextPutAll:"]=13;
+//>>excludeEnd("ctx");
+return $3;
+//>>excludeStart("ctx", pragmas.excludeDebugContexts);
+}, function($ctx3) {$ctx3.fillBlock({each:each},$ctx2,5)});
+//>>excludeEnd("ctx");
+}),(function(){
+//>>excludeStart("ctx", pragmas.excludeDebugContexts);
+return $core.withContext(function($ctx3) {
+//>>excludeEnd("ctx");
+$recv(aStream)._nextPutAll_(",");
+//>>excludeStart("ctx", pragmas.excludeDebugContexts);
+$ctx3.sendIdx["nextPutAll:"]=14;
+//>>excludeEnd("ctx");
+$4=$recv(aStream)._lf();
+//>>excludeStart("ctx", pragmas.excludeDebugContexts);
+$ctx3.sendIdx["lf"]=3;
+//>>excludeEnd("ctx");
+return $4;
+//>>excludeStart("ctx", pragmas.excludeDebugContexts);
+}, function($ctx3) {$ctx3.fillBlock({},$ctx2,6)});
+//>>excludeEnd("ctx");
+}));
+$recv(aStream)._lf();
+//>>excludeStart("ctx", pragmas.excludeDebugContexts);
+$ctx2.sendIdx["lf"]=4;
+//>>excludeEnd("ctx");
+$recv(aStream)._nextPutAll_("};");
+//>>excludeStart("ctx", pragmas.excludeDebugContexts);
+$ctx2.sendIdx["nextPutAll:"]=15;
+//>>excludeEnd("ctx");
+$recv(aStream)._lf();
+//>>excludeStart("ctx", pragmas.excludeDebugContexts);
+$ctx2.sendIdx["lf"]=5;
+//>>excludeEnd("ctx");
+$recv(aStream)._nextPutAll_("});");
+$5=$recv(aStream)._lf();
+return $5;
+//>>excludeStart("ctx", pragmas.excludeDebugContexts);
+}, function($ctx2) {$ctx2.fillBlock({namedImports:namedImports,anonImports:anonImports,importVarNames:importVarNames},$ctx1,1)});
+//>>excludeEnd("ctx");
+}));
+return self;
+//>>excludeStart("ctx", pragmas.excludeDebugContexts);
+}, function($ctx1) {$ctx1.fill(self,"exportPackageImportsFileOf:on:",{aPackage:aPackage,aStream:aStream},$globals.AmdExporter)});
+//>>excludeEnd("ctx");
+},
+//>>excludeStart("ide", pragmas.excludeIdeData);
+args: ["aPackage", "aStream"],
+source: "exportPackageImportsFileOf: aPackage on: aStream\x0a\x09aPackage imports ifNotEmpty: [\x0a\x09\x09| namedImports anonImports importVarNames |\x0a\x09\x09namedImports := #().\x0a\x09\x09anonImports := #().\x0a\x09\x09importVarNames := #().\x0a\x09\x09aPackage sortedImportsAsArray do: [ :each | each isString\x0a\x09\x09\x09ifTrue: [ anonImports add: each ]\x0a\x09\x09\x09ifFalse: [ namedImports add: each value.\x0a\x09\x09\x09\x09importVarNames add: each key ]].\x0a\x09\x09aStream\x0a\x09\x09\x09nextPutAll: 'define(\x22';\x0a\x09\x09\x09nextPutAll: (self amdNamespaceOfPackage: aPackage);\x0a\x09\x09\x09nextPutAll: '/'; \x0a\x09\x09\x09nextPutAll: aPackage name;\x0a\x09\x09\x09nextPutAll: '%Imports\x22, ';\x0a\x09\x09\x09nextPutAll: (namedImports, anonImports) asJavascript;\x0a\x09\x09\x09nextPutAll: ', function(';\x0a\x09\x09\x09nextPutAll: (importVarNames join: ',');\x0a\x09\x09\x09nextPutAll: '){';\x0a\x09\x09\x09lf;\x0a\x09\x09\x09nextPutAll: 'return {';\x0a\x09\x09\x09lf.\x0a\x09\x09importVarNames\x0a\x09\x09\x09do: [ :each | aStream\x0a\x09\x09\x09\x09tab;\x0a\x09\x09\x09\x09nextPutAll: each;\x0a\x09\x09\x09\x09nextPutAll: ': ';\x0a\x09\x09\x09\x09nextPutAll: each ]\x0a\x09\x09\x09separatedBy: [ aStream nextPutAll: ','; lf ].\x0a\x09\x09aStream\x0a\x09\x09\x09lf;\x0a\x09\x09\x09nextPutAll: '};';\x0a\x09\x09\x09lf;\x0a\x09\x09\x09nextPutAll: '});';\x0a\x09\x09\x09lf ]",
+referencedClasses: [],
+//>>excludeEnd("ide");
+messageSends: ["ifNotEmpty:", "imports", "do:", "sortedImportsAsArray", "ifTrue:ifFalse:", "isString", "add:", "value", "key", "nextPutAll:", "amdNamespaceOfPackage:", "name", "asJavascript", ",", "join:", "lf", "do:separatedBy:", "tab"]
+}),
+$globals.AmdExporter);
+
+$core.addMethod(
+$core.method({
+selector: "exportPackagePrologueOf:on:",
+protocol: 'output',
+fn: function (aPackage,aStream){
+var self=this;
+var importVarNames,loadDependencies,useImports;
+//>>excludeStart("ctx", pragmas.excludeDebugContexts);
+return $core.withContext(function($ctx1) {
+//>>excludeEnd("ctx");
+var $1,$5,$7,$9,$8,$6,$4,$3,$2,$13,$12,$11,$10,$14,$15,$16;
+importVarNames=$recv($recv($recv(aPackage)._sortedImportsAsArray())._reject_("isString"))._collect_("key");
 loadDependencies=self._amdNamesOfPackages_($recv(aPackage)._loadDependencies());
+useImports=$recv($recv(aPackage)._imports())._notEmpty();
 $recv(aStream)._nextPutAll_("define(\x22");
 //>>excludeStart("ctx", pragmas.excludeDebugContexts);
 $ctx1.sendIdx["nextPutAll:"]=1;
@@ -1996,7 +2154,11 @@ $recv(aStream)._nextPutAll_("/");
 //>>excludeStart("ctx", pragmas.excludeDebugContexts);
 $ctx1.sendIdx["nextPutAll:"]=3;
 //>>excludeEnd("ctx");
-$recv(aStream)._nextPutAll_($recv(aPackage)._name());
+$1=$recv(aPackage)._name();
+//>>excludeStart("ctx", pragmas.excludeDebugContexts);
+$ctx1.sendIdx["name"]=1;
+//>>excludeEnd("ctx");
+$recv(aStream)._nextPutAll_($1);
 //>>excludeStart("ctx", pragmas.excludeDebugContexts);
 $ctx1.sendIdx["nextPutAll:"]=4;
 //>>excludeEnd("ctx");
@@ -2004,11 +2166,22 @@ $recv(aStream)._nextPutAll_("\x22, ");
 //>>excludeStart("ctx", pragmas.excludeDebugContexts);
 $ctx1.sendIdx["nextPutAll:"]=5;
 //>>excludeEnd("ctx");
-$5=["amber/boot"].__comma(namedImports);
+$5=["amber/boot"];
+$7=useImports;
+if($core.assert($7)){
+$9="./".__comma($recv(aPackage)._name());
+//>>excludeStart("ctx", pragmas.excludeDebugContexts);
+$ctx1.sendIdx[","]=4;
+//>>excludeEnd("ctx");
+$8=$recv($9).__comma("%Imports");
 //>>excludeStart("ctx", pragmas.excludeDebugContexts);
 $ctx1.sendIdx[","]=3;
 //>>excludeEnd("ctx");
-$4=$recv($5).__comma(anonImports);
+$6=[$8];
+} else {
+$6=[];
+};
+$4=$recv($5).__comma($6);
 //>>excludeStart("ctx", pragmas.excludeDebugContexts);
 $ctx1.sendIdx[","]=2;
 //>>excludeEnd("ctx");
@@ -2021,35 +2194,91 @@ $recv(aStream)._nextPutAll_($2);
 //>>excludeStart("ctx", pragmas.excludeDebugContexts);
 $ctx1.sendIdx["nextPutAll:"]=6;
 //>>excludeEnd("ctx");
-$recv(aStream)._nextPutAll_(", function(");
+$13=useImports;
+if($core.assert($13)){
+$12=",$imports";
+} else {
+$12="";
+};
+$11=", function($boot".__comma($12);
+$10=$recv($11).__comma("){");
+//>>excludeStart("ctx", pragmas.excludeDebugContexts);
+$ctx1.sendIdx[","]=5;
+//>>excludeEnd("ctx");
+$recv(aStream)._nextPutAll_($10);
 //>>excludeStart("ctx", pragmas.excludeDebugContexts);
 $ctx1.sendIdx["nextPutAll:"]=7;
-//>>excludeEnd("ctx");
-$recv(aStream)._nextPutAll_($recv(["$boot"].__comma(importVarNames))._join_(","));
-//>>excludeStart("ctx", pragmas.excludeDebugContexts);
-$ctx1.sendIdx["nextPutAll:"]=8;
-//>>excludeEnd("ctx");
-$recv(aStream)._nextPutAll_("){");
-//>>excludeStart("ctx", pragmas.excludeDebugContexts);
-$ctx1.sendIdx["nextPutAll:"]=9;
 //>>excludeEnd("ctx");
 $recv(aStream)._lf();
 //>>excludeStart("ctx", pragmas.excludeDebugContexts);
 $ctx1.sendIdx["lf"]=1;
 //>>excludeEnd("ctx");
 $recv(aStream)._nextPutAll_("var $core=$boot.api,nil=$boot.nil,$recv=$boot.asReceiver,$globals=$boot.globals;");
-$6=$recv(aStream)._lf();
+//>>excludeStart("ctx", pragmas.excludeDebugContexts);
+$ctx1.sendIdx["nextPutAll:"]=8;
+//>>excludeEnd("ctx");
+$14=$recv(aStream)._lf();
+//>>excludeStart("ctx", pragmas.excludeDebugContexts);
+$ctx1.sendIdx["lf"]=2;
+//>>excludeEnd("ctx");
+$recv(importVarNames)._ifNotEmpty_((function(){
+//>>excludeStart("ctx", pragmas.excludeDebugContexts);
+return $core.withContext(function($ctx2) {
+//>>excludeEnd("ctx");
+$recv(aStream)._nextPutAll_("var ");
+//>>excludeStart("ctx", pragmas.excludeDebugContexts);
+$ctx2.sendIdx["nextPutAll:"]=9;
+//>>excludeEnd("ctx");
+$recv(importVarNames)._do_separatedBy_((function(each){
+//>>excludeStart("ctx", pragmas.excludeDebugContexts);
+return $core.withContext(function($ctx3) {
+//>>excludeEnd("ctx");
+$recv(aStream)._nextPutAll_(each);
+//>>excludeStart("ctx", pragmas.excludeDebugContexts);
+$ctx3.sendIdx["nextPutAll:"]=10;
+//>>excludeEnd("ctx");
+$recv(aStream)._nextPutAll_("=$imports.");
+//>>excludeStart("ctx", pragmas.excludeDebugContexts);
+$ctx3.sendIdx["nextPutAll:"]=11;
+//>>excludeEnd("ctx");
+$15=$recv(aStream)._nextPutAll_(each);
+//>>excludeStart("ctx", pragmas.excludeDebugContexts);
+$ctx3.sendIdx["nextPutAll:"]=12;
+//>>excludeEnd("ctx");
+return $15;
+//>>excludeStart("ctx", pragmas.excludeDebugContexts);
+}, function($ctx3) {$ctx3.fillBlock({each:each},$ctx2,6)});
+//>>excludeEnd("ctx");
+}),(function(){
+//>>excludeStart("ctx", pragmas.excludeDebugContexts);
+return $core.withContext(function($ctx3) {
+//>>excludeEnd("ctx");
+return $recv(aStream)._nextPutAll_(",");
+//>>excludeStart("ctx", pragmas.excludeDebugContexts);
+$ctx3.sendIdx["nextPutAll:"]=13;
+//>>excludeEnd("ctx");
+//>>excludeStart("ctx", pragmas.excludeDebugContexts);
+}, function($ctx3) {$ctx3.fillBlock({},$ctx2,7)});
+//>>excludeEnd("ctx");
+}));
+$recv(aStream)._nextPutAll_(";");
+$16=$recv(aStream)._lf();
+return $16;
+//>>excludeStart("ctx", pragmas.excludeDebugContexts);
+}, function($ctx2) {$ctx2.fillBlock({},$ctx1,5)});
+//>>excludeEnd("ctx");
+}));
 return self;
 //>>excludeStart("ctx", pragmas.excludeDebugContexts);
-}, function($ctx1) {$ctx1.fill(self,"exportPackagePrologueOf:on:",{aPackage:aPackage,aStream:aStream,namedImports:namedImports,anonImports:anonImports,importVarNames:importVarNames,loadDependencies:loadDependencies},$globals.AmdExporter)});
+}, function($ctx1) {$ctx1.fill(self,"exportPackagePrologueOf:on:",{aPackage:aPackage,aStream:aStream,importVarNames:importVarNames,loadDependencies:loadDependencies,useImports:useImports},$globals.AmdExporter)});
 //>>excludeEnd("ctx");
 },
 //>>excludeStart("ide", pragmas.excludeIdeData);
 args: ["aPackage", "aStream"],
-source: "exportPackagePrologueOf: aPackage on: aStream\x0a\x09| namedImports anonImports importVarNames loadDependencies |\x0a\x09namedImports := #().\x0a\x09anonImports := #().\x0a\x09importVarNames := #().\x0a\x09aPackage imports do: [ :each | each isString\x0a\x09\x09ifTrue: [ anonImports add: each ]\x0a\x09\x09ifFalse: [ namedImports add: each value.\x0a\x09\x09\x09importVarNames add: each key ]].\x0a\x09loadDependencies := self amdNamesOfPackages: aPackage loadDependencies.\x0a\x09aStream\x0a\x09\x09nextPutAll: 'define(\x22';\x0a\x09\x09nextPutAll: (self amdNamespaceOfPackage: aPackage);\x0a\x09\x09nextPutAll: '/'; \x0a\x09\x09nextPutAll: aPackage name;\x0a\x09\x09nextPutAll: '\x22, ';\x0a\x09\x09nextPutAll: (#('amber/boot'), namedImports, anonImports, loadDependencies) asJavascript;\x0a\x09\x09nextPutAll: ', function(';\x0a\x09\x09nextPutAll: (#('$boot'), importVarNames join: ',');\x0a\x09\x09nextPutAll: '){';\x0a\x09\x09lf;\x0a\x09\x09nextPutAll: 'var $core=$boot.api,nil=$boot.nil,$recv=$boot.asReceiver,$globals=$boot.globals;';\x0a\x09\x09lf",
+source: "exportPackagePrologueOf: aPackage on: aStream\x0a\x09| importVarNames loadDependencies useImports |\x0a\x09importVarNames := (aPackage sortedImportsAsArray reject: #isString) collect: #key.\x0a\x09loadDependencies := self amdNamesOfPackages: aPackage loadDependencies.\x0a\x09useImports := aPackage imports notEmpty.\x0a\x09aStream\x0a\x09\x09nextPutAll: 'define(\x22';\x0a\x09\x09nextPutAll: (self amdNamespaceOfPackage: aPackage);\x0a\x09\x09nextPutAll: '/'; \x0a\x09\x09nextPutAll: aPackage name;\x0a\x09\x09nextPutAll: '\x22, ';\x0a\x09\x09nextPutAll: (#('amber/boot'),\x0a\x09\x09\x09(useImports ifTrue: [{'./', aPackage name, '%Imports'}] ifFalse: [#()]),\x0a\x09\x09\x09loadDependencies) asJavascript;\x0a\x09\x09nextPutAll: ', function($boot',\x0a\x09\x09\x09(useImports ifTrue: [',$imports'] ifFalse: ['']),\x0a\x09\x09\x09'){';\x0a\x09\x09lf;\x0a\x09\x09nextPutAll: 'var $core=$boot.api,nil=$boot.nil,$recv=$boot.asReceiver,$globals=$boot.globals;';\x0a\x09\x09lf.\x0a\x09importVarNames ifNotEmpty: [\x0a\x09\x09aStream nextPutAll: 'var '.\x0a\x09\x09importVarNames\x0a\x09\x09\x09do: [ :each | aStream nextPutAll: each; nextPutAll: '=$imports.'; nextPutAll: each ]\x0a\x09\x09\x09separatedBy: [ aStream nextPutAll: ',' ].\x0a\x09\x09aStream nextPutAll: ';'; lf ]",
 referencedClasses: [],
 //>>excludeEnd("ide");
-messageSends: ["do:", "imports", "ifTrue:ifFalse:", "isString", "add:", "value", "key", "amdNamesOfPackages:", "loadDependencies", "nextPutAll:", "amdNamespaceOfPackage:", "name", "asJavascript", ",", "join:", "lf"]
+messageSends: ["collect:", "reject:", "sortedImportsAsArray", "amdNamesOfPackages:", "loadDependencies", "notEmpty", "imports", "nextPutAll:", "amdNamespaceOfPackage:", "name", "asJavascript", ",", "ifTrue:ifFalse:", "lf", "ifNotEmpty:", "do:separatedBy:"]
 }),
 $globals.AmdExporter);
 
@@ -2829,35 +3058,64 @@ selector: "contentsFor:",
 protocol: 'accessing',
 fn: function (aPackage){
 var self=this;
+var files,contents;
 function $Dictionary(){return $globals.Dictionary||(typeof Dictionary=="undefined"?nil:Dictionary)}
 function $String(){return $globals.String||(typeof String=="undefined"?nil:String)}
 //>>excludeStart("ctx", pragmas.excludeDebugContexts);
 return $core.withContext(function($ctx1) {
 //>>excludeEnd("ctx");
-var $2,$3,$1;
-$2=$recv($Dictionary())._new();
-$recv($2)._at_put_(".js",$recv($String())._streamContents_((function(str){
+var $1,$2;
+files=$recv($Dictionary())._new();
+contents=$recv($String())._streamContents_((function(str){
 //>>excludeStart("ctx", pragmas.excludeDebugContexts);
 return $core.withContext(function($ctx2) {
 //>>excludeEnd("ctx");
-return $recv(self._exporter())._exportPackage_on_(aPackage,str);
+$1=self._exporter();
+//>>excludeStart("ctx", pragmas.excludeDebugContexts);
+$ctx2.sendIdx["exporter"]=1;
+//>>excludeEnd("ctx");
+return $recv($1)._exportPackage_on_(aPackage,str);
 //>>excludeStart("ctx", pragmas.excludeDebugContexts);
 }, function($ctx2) {$ctx2.fillBlock({str:str},$ctx1,1)});
 //>>excludeEnd("ctx");
-})));
-$3=$recv($2)._yourself();
-$1=$3;
-return $1;
+}));
 //>>excludeStart("ctx", pragmas.excludeDebugContexts);
-}, function($ctx1) {$ctx1.fill(self,"contentsFor:",{aPackage:aPackage},$globals.PackageHandler)});
+$ctx1.sendIdx["streamContents:"]=1;
+//>>excludeEnd("ctx");
+$recv(files)._at_put_(".js",contents);
+//>>excludeStart("ctx", pragmas.excludeDebugContexts);
+$ctx1.sendIdx["at:put:"]=1;
+//>>excludeEnd("ctx");
+contents=$recv($String())._streamContents_((function(str){
+//>>excludeStart("ctx", pragmas.excludeDebugContexts);
+return $core.withContext(function($ctx2) {
+//>>excludeEnd("ctx");
+return $recv(self._exporter())._exportPackageImportsFileOf_on_(aPackage,str);
+//>>excludeStart("ctx", pragmas.excludeDebugContexts);
+}, function($ctx2) {$ctx2.fillBlock({str:str},$ctx1,2)});
+//>>excludeEnd("ctx");
+}));
+$recv(contents)._ifNotEmpty_((function(){
+//>>excludeStart("ctx", pragmas.excludeDebugContexts);
+return $core.withContext(function($ctx2) {
+//>>excludeEnd("ctx");
+return $recv(files)._at_put_("%Imports.js",contents);
+//>>excludeStart("ctx", pragmas.excludeDebugContexts);
+}, function($ctx2) {$ctx2.fillBlock({},$ctx1,3)});
+//>>excludeEnd("ctx");
+}));
+$2=files;
+return $2;
+//>>excludeStart("ctx", pragmas.excludeDebugContexts);
+}, function($ctx1) {$ctx1.fill(self,"contentsFor:",{aPackage:aPackage,files:files,contents:contents},$globals.PackageHandler)});
 //>>excludeEnd("ctx");
 },
 //>>excludeStart("ide", pragmas.excludeIdeData);
 args: ["aPackage"],
-source: "contentsFor: aPackage\x0a\x09^ Dictionary new\x0a\x09\x09at: '.js' put: (String streamContents: [ :str |\x0a\x09\x09\x09self exporter exportPackage: aPackage on: str ]);\x0a\x09\x09yourself",
+source: "contentsFor: aPackage\x0a\x09| files contents |\x0a\x09files := Dictionary new.\x0a\x09contents := String streamContents: [ :str |\x0a\x09\x09self exporter exportPackage: aPackage on: str ].\x0a\x09files at: '.js' put: contents.\x0a\x09contents := String streamContents: [ :str |\x0a\x09\x09self exporter exportPackageImportsFileOf: aPackage on: str ].\x0a\x09contents ifNotEmpty: [ files at: '%Imports.js' put: contents ].\x0a\x09^ files",
 referencedClasses: ["Dictionary", "String"],
 //>>excludeEnd("ide");
-messageSends: ["at:put:", "new", "streamContents:", "exportPackage:on:", "exporter", "yourself"]
+messageSends: ["new", "streamContents:", "exportPackage:on:", "exporter", "at:put:", "exportPackageImportsFileOf:on:", "ifNotEmpty:"]
 }),
 $globals.PackageHandler);
 

--- a/src/Kernel-ImportExport.st
+++ b/src/Kernel-ImportExport.st
@@ -376,6 +376,10 @@ exportPackageEpilogueOf: aPackage on: aStream
 	self subclassResponsibility
 !
 
+exportPackageImportsFileOf: aPackage on: aStream
+	"do nothing"
+!
+
 exportPackageImportsOf: aPackage on: aStream
 	aPackage importsAsJson ifNotEmpty: [ :imports |
 		aStream
@@ -415,29 +419,70 @@ exportPackageEpilogueOf: aPackage on: aStream
 		lf
 !
 
+exportPackageImportsFileOf: aPackage on: aStream
+	aPackage imports ifNotEmpty: [
+		| namedImports anonImports importVarNames |
+		namedImports := #().
+		anonImports := #().
+		importVarNames := #().
+		aPackage sortedImportsAsArray do: [ :each | each isString
+			ifTrue: [ anonImports add: each ]
+			ifFalse: [ namedImports add: each value.
+				importVarNames add: each key ]].
+		aStream
+			nextPutAll: 'define("';
+			nextPutAll: (self amdNamespaceOfPackage: aPackage);
+			nextPutAll: '/'; 
+			nextPutAll: aPackage name;
+			nextPutAll: '%Imports", ';
+			nextPutAll: (namedImports, anonImports) asJavascript;
+			nextPutAll: ', function(';
+			nextPutAll: (importVarNames join: ',');
+			nextPutAll: '){';
+			lf;
+			nextPutAll: 'return {';
+			lf.
+		importVarNames
+			do: [ :each | aStream
+				tab;
+				nextPutAll: each;
+				nextPutAll: ': ';
+				nextPutAll: each ]
+			separatedBy: [ aStream nextPutAll: ','; lf ].
+		aStream
+			lf;
+			nextPutAll: '};';
+			lf;
+			nextPutAll: '});';
+			lf ]
+!
+
 exportPackagePrologueOf: aPackage on: aStream
-	| namedImports anonImports importVarNames loadDependencies |
-	namedImports := #().
-	anonImports := #().
-	importVarNames := #().
-	aPackage imports do: [ :each | each isString
-		ifTrue: [ anonImports add: each ]
-		ifFalse: [ namedImports add: each value.
-			importVarNames add: each key ]].
+	| importVarNames loadDependencies useImports |
+	importVarNames := (aPackage sortedImportsAsArray reject: #isString) collect: #key.
 	loadDependencies := self amdNamesOfPackages: aPackage loadDependencies.
+	useImports := aPackage imports notEmpty.
 	aStream
 		nextPutAll: 'define("';
 		nextPutAll: (self amdNamespaceOfPackage: aPackage);
 		nextPutAll: '/'; 
 		nextPutAll: aPackage name;
 		nextPutAll: '", ';
-		nextPutAll: (#('amber/boot'), namedImports, anonImports, loadDependencies) asJavascript;
-		nextPutAll: ', function(';
-		nextPutAll: (#('$boot'), importVarNames join: ',');
-		nextPutAll: '){';
+		nextPutAll: (#('amber/boot'),
+			(useImports ifTrue: [{'./', aPackage name, '%Imports'}] ifFalse: [#()]),
+			loadDependencies) asJavascript;
+		nextPutAll: ', function($boot',
+			(useImports ifTrue: [',$imports'] ifFalse: ['']),
+			'){';
 		lf;
 		nextPutAll: 'var $core=$boot.api,nil=$boot.nil,$recv=$boot.asReceiver,$globals=$boot.globals;';
-		lf
+		lf.
+	importVarNames ifNotEmpty: [
+		aStream nextPutAll: 'var '.
+		importVarNames
+			do: [ :each | aStream nextPutAll: each; nextPutAll: '=$imports.'; nextPutAll: each ]
+			separatedBy: [ aStream nextPutAll: ',' ].
+		aStream nextPutAll: ';'; lf ]
 ! !
 
 !AmdExporter methodsFor: 'private'!
@@ -620,10 +665,15 @@ commitPathStFor: aPackage
 !
 
 contentsFor: aPackage
-	^ Dictionary new
-		at: '.js' put: (String streamContents: [ :str |
-			self exporter exportPackage: aPackage on: str ]);
-		yourself
+	| files contents |
+	files := Dictionary new.
+	contents := String streamContents: [ :str |
+		self exporter exportPackage: aPackage on: str ].
+	files at: '.js' put: contents.
+	contents := String streamContents: [ :str |
+		self exporter exportPackageImportsFileOf: aPackage on: str ].
+	contents ifNotEmpty: [ files at: '%Imports.js' put: contents ].
+	^ files
 !
 
 exporterClass

--- a/src/Kernel-ImportExport.st
+++ b/src/Kernel-ImportExport.st
@@ -620,8 +620,10 @@ commitPathStFor: aPackage
 !
 
 contentsFor: aPackage
-	^ String streamContents: [ :str |
-		self exporter exportPackage: aPackage on: str ]
+	^ Dictionary new
+		at: '.js' put: (String streamContents: [ :str |
+			self exporter exportPackage: aPackage on: str ]);
+		yourself
 !
 
 exporterClass
@@ -651,10 +653,28 @@ commit: aPackage onSuccess: aBlock onError: anotherBlock
 		onError: anotherBlock
 !
 
+commitFiles: aDictionary toPathPrefix: aString onSuccess: aBlock onError: anotherBlock
+	aDictionary ifEmpty: aBlock ifNotEmpty: [
+		| ext contents |
+		ext := aDictionary keys anyOne.
+		contents := aDictionary at: ext.
+		self 
+			ajaxPutAt: aString, ext
+				data: contents
+				onSuccess: [
+					aDictionary removeKey: ext.
+					self
+						commitFiles: aDictionary
+						toPathPrefix: aString
+						onSuccess: aBlock
+						onError: anotherBlock ]
+				onError: anotherBlock ]
+!
+
 commitJsFileFor: aPackage onSuccess: aBlock onError: anotherBlock
-	self 
-		ajaxPutAt: (self commitPathJsFor: aPackage), '/', aPackage name, '.js'
-		data: (self contentsFor: aPackage)
+	self
+		commitFiles: (self contentsFor: aPackage)
+		toPathPrefix: (self commitPathJsFor: aPackage), '/', aPackage name
 		onSuccess: aBlock
 		onError: anotherBlock
 !

--- a/src/Web%Imports.js
+++ b/src/Web%Imports.js
@@ -1,0 +1,5 @@
+define("amber_core/Web%Imports", ["jquery"], function(jQuery){
+return {
+	jQuery: jQuery
+};
+});

--- a/src/Web.js
+++ b/src/Web.js
@@ -1,5 +1,6 @@
-define("amber_core/Web", ["amber/boot", "jquery", "amber_core/Kernel-Objects", "amber_core/Kernel-Infrastructure", "amber_core/Kernel-Methods", "amber_core/Kernel-Collections"], function($boot,jQuery){
+define("amber_core/Web", ["amber/boot", "./Web%Imports", "amber_core/Kernel-Objects", "amber_core/Kernel-Infrastructure", "amber_core/Kernel-Methods", "amber_core/Kernel-Collections"], function($boot,$imports){
 var $core=$boot.api,nil=$boot.nil,$recv=$boot.asReceiver,$globals=$boot.globals;
+var jQuery=$imports.jQuery;
 $core.addPackage('Web');
 $core.packages["Web"].innerEval = function (expr) { return eval(expr); };
 $core.packages["Web"].imports = ["jQuery=jquery"];

--- a/support/boot.js
+++ b/support/boot.js
@@ -304,7 +304,7 @@ define("amber/boot", [ 'require', './browser-compatibility' ], function (require
 		 If package already exists we still update the properties of it. */
 
 		st.addPackage = function(pkgName, properties) {
-			if(!pkgName) {return nil;}
+			if(!pkgName || pkgName.match(/[\x00-\x1f\x80-\x9f*?:<>|/\\#!@%]/)) {return nil;}
 			if(!(st.packages[pkgName])) {
 				st.packages[pkgName] = pkg({
 					pkgName: pkgName,


### PR DESCRIPTION
A `.js` file for package `Foo` now only includes one additional dependency named `./Foo%Imports` into its `define` call, and package commit additionally outputs one more .js file for module `Foo%Imports` that actually load all external dependencies (see aff5bdd).

This consistent naming allows for fixing #1145 in cli compiler by trivially faking `Foo%Imports` for every library `Foo`. 