### PR TITLE
upgrade to Grunt 0.4.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "amber-dev": "^0.4.0",
-    "grunt": "^0.4.0",
+    "grunt": "^0.4.5",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-jshint": "^0.11.0",
     "grunt-execute": "^0.2.1",


### PR DESCRIPTION
The upgrade does not seem to produce any issues, since running `grunt` finished without any errors.