### PR TITLE
Remove node version check

### DIFF
--- a/external/amber-cli/package.json
+++ b/external/amber-cli/package.json
@@ -23,7 +23,7 @@
     "url": "git://github.com/amber-smalltalk/amber.git"
   },
   "engines": {
-    "node": ">=0.10.0 <0.13.0"
+    "node": ">=0.10.0 <0.13.0 || >=4.0.0"
   },
   "bugs": {
     "url": "https://github.com/amber-smalltalk/amber/issues?labels=in+cli"

--- a/external/amber-cli/package.json
+++ b/external/amber-cli/package.json
@@ -23,7 +23,7 @@
     "url": "git://github.com/amber-smalltalk/amber.git"
   },
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=0.10.0 <0.13.0"
   },
   "bugs": {
     "url": "https://github.com/amber-smalltalk/amber/issues?labels=in+cli"

--- a/external/amber-cli/src/AmberCli.js
+++ b/external/amber-cli/src/AmberCli.js
@@ -188,22 +188,14 @@ selector: "main",
 protocol: 'startup',
 fn: function (){
 var self=this;
-var args,nodeMinorVersion;
+var args;
 function $Transcript(){return $globals.Transcript||(typeof Transcript=="undefined"?nil:Transcript)}
 function $Smalltalk(){return $globals.Smalltalk||(typeof Smalltalk=="undefined"?nil:Smalltalk)}
 //>>excludeStart("ctx", pragmas.excludeDebugContexts);
 return $core.withContext(function($ctx1) {
 //>>excludeEnd("ctx");
-var $5,$4,$3,$2,$1,$8,$7,$6,$9,$10,$11;
-$5=$recv($Smalltalk())._version();
-//>>excludeStart("ctx", pragmas.excludeDebugContexts);
-$ctx1.sendIdx["version"]=1;
-//>>excludeEnd("ctx");
-$4="Welcome to Amber version ".__comma($5);
-//>>excludeStart("ctx", pragmas.excludeDebugContexts);
-$ctx1.sendIdx[","]=4;
-//>>excludeEnd("ctx");
-$3=$recv($4).__comma(" (NodeJS ");
+var $3,$2,$1,$4,$5;
+$3=$recv("Welcome to Amber version ".__comma($recv($Smalltalk())._version())).__comma(" (NodeJS ");
 //>>excludeStart("ctx", pragmas.excludeDebugContexts);
 $ctx1.sendIdx[","]=3;
 //>>excludeEnd("ctx");
@@ -216,45 +208,26 @@ $1=$recv($2).__comma(").");
 $ctx1.sendIdx[","]=1;
 //>>excludeEnd("ctx");
 $recv($Transcript())._show_($1);
-//>>excludeStart("ctx", pragmas.excludeDebugContexts);
-$ctx1.sendIdx["show:"]=1;
-//>>excludeEnd("ctx");
-$8=$recv(process)._version();
-//>>excludeStart("ctx", pragmas.excludeDebugContexts);
-$ctx1.sendIdx["version"]=2;
-//>>excludeEnd("ctx");
-$7=$recv($8)._tokenize_(".");
-$6=$recv($7)._second();
-nodeMinorVersion=$recv($6)._asNumber();
-$9=$recv(nodeMinorVersion).__lt((8));
-if($core.assert($9)){
-$recv($Transcript())._show_("You are currently using Node.js ".__comma($recv(process)._version()));
-//>>excludeStart("ctx", pragmas.excludeDebugContexts);
-$ctx1.sendIdx["show:"]=2;
-//>>excludeEnd("ctx");
-$recv($Transcript())._show_("Required is at least Node.js v0.8.x or greater.");
-return (-1);
-};
 args=$recv(process)._argv();
 $recv(args)._removeFrom_to_((1),(2));
-$10=$recv(args)._isEmpty();
-if($core.assert($10)){
+$4=$recv(args)._isEmpty();
+if($core.assert($4)){
 self._help_(nil);
 } else {
-$11=self._handleArguments_(args);
-return $11;
+$5=self._handleArguments_(args);
+return $5;
 };
 return self;
 //>>excludeStart("ctx", pragmas.excludeDebugContexts);
-}, function($ctx1) {$ctx1.fill(self,"main",{args:args,nodeMinorVersion:nodeMinorVersion},$globals.AmberCli.klass)});
+}, function($ctx1) {$ctx1.fill(self,"main",{args:args},$globals.AmberCli.klass)});
 //>>excludeEnd("ctx");
 },
 //>>excludeStart("ide", pragmas.excludeIdeData);
 args: [],
-source: "main\x0a\x09\x22Main entry point for Amber applications.\x0a\x09Parses commandline arguments and starts the according subprogram.\x22\x0a\x09| args nodeMinorVersion |\x0a\x09\x0a\x09Transcript show: 'Welcome to Amber version ', Smalltalk version, ' (NodeJS ', process versions node, ').'.\x0a\x0a\x09nodeMinorVersion := ((process version) tokenize: '.') second asNumber.\x0a\x09nodeMinorVersion < 8 ifTrue: [\x0a\x09\x09Transcript show: 'You are currently using Node.js ', (process version).\x0a\x09\x09Transcript show: 'Required is at least Node.js v0.8.x or greater.'.\x0a\x09\x09^ -1.\x0a\x09].\x0a\x0a\x09args := process argv.\x0a\x09\x22Remove the first args which contain the path to the node executable and the script file.\x22\x0a\x09args removeFrom: 1 to: 2.\x0a\x09\x0a\x09(args isEmpty)\x0a\x09\x09ifTrue: [self help: nil]\x0a\x09\x09ifFalse: [^self handleArguments: args]",
+source: "main\x0a\x09\x22Main entry point for Amber applications.\x0a\x09Parses commandline arguments and starts the according subprogram.\x22\x0a\x09| args |\x0a\x09\x0a\x09Transcript show: 'Welcome to Amber version ', Smalltalk version, ' (NodeJS ', process versions node, ').'.\x0a\x0a\x09args := process argv.\x0a\x09\x22Remove the first args which contain the path to the node executable and the script file.\x22\x0a\x09args removeFrom: 1 to: 2.\x0a\x09\x0a\x09(args isEmpty)\x0a\x09\x09ifTrue: [self help: nil]\x0a\x09\x09ifFalse: [^self handleArguments: args]",
 referencedClasses: ["Transcript", "Smalltalk"],
 //>>excludeEnd("ide");
-messageSends: ["show:", ",", "version", "node", "versions", "asNumber", "second", "tokenize:", "ifTrue:", "<", "argv", "removeFrom:to:", "ifTrue:ifFalse:", "isEmpty", "help:", "handleArguments:"]
+messageSends: ["show:", ",", "version", "node", "versions", "argv", "removeFrom:to:", "ifTrue:ifFalse:", "isEmpty", "help:", "handleArguments:"]
 }),
 $globals.AmberCli.klass);
 

--- a/external/amber-cli/src/AmberCli.st
+++ b/external/amber-cli/src/AmberCli.st
@@ -84,16 +84,9 @@ version: arguments
 main
 	"Main entry point for Amber applications.
 	Parses commandline arguments and starts the according subprogram."
-	| args nodeMinorVersion |
+	| args |
 	
 	Transcript show: 'Welcome to Amber version ', Smalltalk version, ' (NodeJS ', process versions node, ').'.
-
-	nodeMinorVersion := ((process version) tokenize: '.') second asNumber.
-	nodeMinorVersion < 8 ifTrue: [
-		Transcript show: 'You are currently using Node.js ', (process version).
-		Transcript show: 'Required is at least Node.js v0.8.x or greater.'.
-		^ -1.
-	].
 
 	args := process argv.
 	"Remove the first args which contain the path to the node executable and the script file."

--- a/external/amber-cli/support/amber-cli.js
+++ b/external/amber-cli/support/amber-cli.js
@@ -805,6 +805,8 @@ define("amber/boot", ['require', './browser-compatibility'], function (require) 
 
         /* Converts a JavaScript object to valid Smalltalk Object */
         st.readJSObject = function (js) {
+            if (js == null)
+                return null;
             var readObject = js.constructor === Object;
             var readArray = js.constructor === Array;
             var object = readObject ? globals.Dictionary._new() : readArray ? [] : js;

--- a/external/amber-cli/support/amber-cli.js
+++ b/external/amber-cli/support/amber-cli.js
@@ -63047,51 +63047,34 @@ selector: "main",
 protocol: 'startup',
 fn: function (){
 var self=this;
-var args,nodeMinorVersion;
+var args;
 function $Transcript(){return $globals.Transcript||(typeof Transcript=="undefined"?nil:Transcript)}
 function $Smalltalk(){return $globals.Smalltalk||(typeof Smalltalk=="undefined"?nil:Smalltalk)}
 return $core.withContext(function($ctx1) {
-var $5,$4,$3,$2,$1,$8,$7,$6,$9,$10,$11;
-$5=$recv($Smalltalk())._version();
-$ctx1.sendIdx["version"]=1;
-$4="Welcome to Amber version ".__comma($5);
-$ctx1.sendIdx[","]=4;
-$3=$recv($4).__comma(" (NodeJS ");
+var $3,$2,$1,$4,$5;
+$3=$recv("Welcome to Amber version ".__comma($recv($Smalltalk())._version())).__comma(" (NodeJS ");
 $ctx1.sendIdx[","]=3;
 $2=$recv($3).__comma($recv($recv(process)._versions())._node());
 $ctx1.sendIdx[","]=2;
 $1=$recv($2).__comma(").");
 $ctx1.sendIdx[","]=1;
 $recv($Transcript())._show_($1);
-$ctx1.sendIdx["show:"]=1;
-$8=$recv(process)._version();
-$ctx1.sendIdx["version"]=2;
-$7=$recv($8)._tokenize_(".");
-$6=$recv($7)._second();
-nodeMinorVersion=$recv($6)._asNumber();
-$9=$recv(nodeMinorVersion).__lt((8));
-if($core.assert($9)){
-$recv($Transcript())._show_("You are currently using Node.js ".__comma($recv(process)._version()));
-$ctx1.sendIdx["show:"]=2;
-$recv($Transcript())._show_("Required is at least Node.js v0.8.x or greater.");
-return (-1);
-};
 args=$recv(process)._argv();
 $recv(args)._removeFrom_to_((1),(2));
-$10=$recv(args)._isEmpty();
-if($core.assert($10)){
+$4=$recv(args)._isEmpty();
+if($core.assert($4)){
 self._help_(nil);
 } else {
-$11=self._handleArguments_(args);
-return $11;
+$5=self._handleArguments_(args);
+return $5;
 };
 return self;
-}, function($ctx1) {$ctx1.fill(self,"main",{args:args,nodeMinorVersion:nodeMinorVersion},$globals.AmberCli.klass)});
+}, function($ctx1) {$ctx1.fill(self,"main",{args:args},$globals.AmberCli.klass)});
 },
 args: [],
-source: "main\x0a\x09\x22Main entry point for Amber applications.\x0a\x09Parses commandline arguments and starts the according subprogram.\x22\x0a\x09| args nodeMinorVersion |\x0a\x09\x0a\x09Transcript show: 'Welcome to Amber version ', Smalltalk version, ' (NodeJS ', process versions node, ').'.\x0a\x0a\x09nodeMinorVersion := ((process version) tokenize: '.') second asNumber.\x0a\x09nodeMinorVersion < 8 ifTrue: [\x0a\x09\x09Transcript show: 'You are currently using Node.js ', (process version).\x0a\x09\x09Transcript show: 'Required is at least Node.js v0.8.x or greater.'.\x0a\x09\x09^ -1.\x0a\x09].\x0a\x0a\x09args := process argv.\x0a\x09\x22Remove the first args which contain the path to the node executable and the script file.\x22\x0a\x09args removeFrom: 1 to: 2.\x0a\x09\x0a\x09(args isEmpty)\x0a\x09\x09ifTrue: [self help: nil]\x0a\x09\x09ifFalse: [^self handleArguments: args]",
+source: "main\x0a\x09\x22Main entry point for Amber applications.\x0a\x09Parses commandline arguments and starts the according subprogram.\x22\x0a\x09| args |\x0a\x09\x0a\x09Transcript show: 'Welcome to Amber version ', Smalltalk version, ' (NodeJS ', process versions node, ').'.\x0a\x0a\x09args := process argv.\x0a\x09\x22Remove the first args which contain the path to the node executable and the script file.\x22\x0a\x09args removeFrom: 1 to: 2.\x0a\x09\x0a\x09(args isEmpty)\x0a\x09\x09ifTrue: [self help: nil]\x0a\x09\x09ifFalse: [^self handleArguments: args]",
 referencedClasses: ["Transcript", "Smalltalk"],
-messageSends: ["show:", ",", "version", "node", "versions", "asNumber", "second", "tokenize:", "ifTrue:", "<", "argv", "removeFrom:to:", "ifTrue:ifFalse:", "isEmpty", "help:", "handleArguments:"]
+messageSends: ["show:", ",", "version", "node", "versions", "argv", "removeFrom:to:", "ifTrue:ifFalse:", "isEmpty", "help:", "handleArguments:"]
 }),
 $globals.AmberCli.klass);
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "git://github.com/amber-smalltalk/amber.git"
   },
   "engines": {
-    "node": ">=0.10.0 <0.13.0"
+    "node": ">=0.10.0 <0.13.0 || >=4.0.0"
   },
   "scripts": {
     "test": "grunt test && cd external && cd amber-cli && npm test && cd .. && cd .."

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "git://github.com/amber-smalltalk/amber.git"
   },
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=0.10.0 <0.13.0"
   },
   "scripts": {
     "test": "grunt test && cd external && cd amber-cli && npm test && cd .. && cd .."

--- a/support/boot.js
+++ b/support/boot.js
@@ -790,6 +790,8 @@ define("amber/boot", ['require', './browser-compatibility'], function (require) 
 
         /* Converts a JavaScript object to valid Smalltalk Object */
         st.readJSObject = function (js) {
+            if (js == null)
+                return null;
             var readObject = js.constructor === Object;
             var readArray = js.constructor === Array;
             var object = readObject ? globals.Dictionary._new() : readArray ? [] : js;


### PR DESCRIPTION
Fix an error where the version check of node is only applied to the minor number.
Since node is now at 4.1.0 the check for the minor version being greated than 8 fails.